### PR TITLE
Add Ability to write Zip File to Buffer instead of File Stream.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ test/okToDeleteMoved.txt
 test/output.zip
 test/test_putOnClosedStream.zip
 test/zipWithDirs_copy.zip
+nbproject/*


### PR DESCRIPTION
The above functionality is convenient for Rails applications where you do not want to deal with unique filename for saving the data to the filesystem.

David
