### PR TITLE
Escape Regex to allow characters such as parentheses into filenames

### DIFF
--- a/lib/zip/zipfilesystem.rb
+++ b/lib/zip/zipfilesystem.rb
@@ -465,7 +465,7 @@ module Zip
           raise Errno::ENOTDIR, aDirectoryName
         end
         path = @file.expand_path(aDirectoryName).ensure_end("/")
-
+	path = Regexp.escape(path)
         subDirEntriesRegex = Regexp.new("^#{path}([^/]+)$")
         @mappedZip.each { 
           |fileName|


### PR DESCRIPTION
Hi,

I've got a one-line code change for your consideration: escaping the regex allows for non-alphanumeric characters in file/directory names to be found through rubyzip methods. We are using it on a project and it would be useful for deployment if we made it into a patch. I hope it helps,

Best Regards,
Dan Garland
