### PR TITLE
Sort Central Directory

### DIFF
--- a/lib/zip/zip_central_directory.rb
+++ b/lib/zip/zip_central_directory.rb
@@ -21,7 +21,7 @@ module Zip
 
     def write_to_stream(io)  #:nodoc:
       offset = io.tell
-      @entrySet.each { |entry| entry.write_c_dir_entry(io) }
+      @entrySet.sort.each { |entry| entry.write_c_dir_entry(io) }
       write_e_o_c_d(io, offset)
     end
 


### PR DESCRIPTION
-Fixes an issue I had by ensuring that it unzips in the correct order

*nix `unzip` unzips in the order the files are listed in the central directory. So although I had my files named 001, 002, etc. they were unzipping in a random order.

This one-liner fixes this issue. (Well for me at least :) )
