### PR TITLE
added ZipInputStream::open_buffer

### DIFF
--- a/lib/zip/zip_input_stream.rb
+++ b/lib/zip/zip_input_stream.rb
@@ -46,10 +46,14 @@ module Zip
     # Opens the indicated zip file. An exception is thrown
     # if the specified offset in the specified filename is
     # not a local zip entry header.
-    def initialize(filename, offset = 0)
+    def initialize(filename, offset = 0, io = nil)
       super()
-      @archiveIO = File.open(filename, "rb")
-      @archiveIO.seek(offset, IO::SEEK_SET)
+      if (io.nil?) 
+        @archiveIO = File.open(filename, "rb")
+        @archiveIO.seek(offset, IO::SEEK_SET)
+      else
+        @archiveIO = io
+      end
       @decompressor = NullDecompressor.instance
       @currentEntry = nil
     end
@@ -65,6 +69,14 @@ module Zip
       return new(filename) unless block_given?
       
       zio = new(filename)
+      yield zio
+    ensure
+      zio.close if zio
+    end
+
+    def ZipInputStream.open_buffer(io)
+      return new('',0,io) unless block_given?
+      zio = new('',0,io)
       yield zio
     ensure
       zio.close if zio

--- a/test/ziptest.rb
+++ b/test/ziptest.rb
@@ -436,6 +436,19 @@ class ZipInputStreamTest < Test::Unit::TestCase
   end
 
   def test_openWithoutBlock
+    zis = ZipInputStream.open_buffer(File.new(TestZipFile::TEST_ZIP2.zip_name, "rb"))
+    assert_stream_contents(zis, TestZipFile::TEST_ZIP2)
+  end
+
+  def test_openBufferWithBlock
+    ZipInputStream.open_buffer(File.new(TestZipFile::TEST_ZIP2.zip_name, "rb")) {
+      |zis|
+      assert_stream_contents(zis, TestZipFile::TEST_ZIP2)
+      assert_equal(true, zis.eof?)
+    }
+  end
+
+  def test_openBufferWithoutBlock
     zis = ZipInputStream.open(TestZipFile::TEST_ZIP2.zip_name)
     assert_stream_contents(zis, TestZipFile::TEST_ZIP2)
   end


### PR DESCRIPTION
ZipInputStream accepts io object instead of file with method open_buffer.
Please consider to merge this.

I want to use rubyzip to parse/create EPUB files on servers with limited access to local filesystem, like Heroku, so need functionality like this.
