### PR TITLE
Do not sort entries on ZipOutputStream.close

### DIFF
--- a/lib/zip/zip_central_directory.rb
+++ b/lib/zip/zip_central_directory.rb
@@ -21,7 +21,7 @@ module Zip
 
     def write_to_stream(io)  #:nodoc:
       offset = io.tell
-      @entrySet.sort.each { |entry| entry.write_c_dir_entry(io) }
+      @entrySet.each { |entry| entry.write_c_dir_entry(io) }
       write_e_o_c_d(io, offset)
     end
 


### PR DESCRIPTION
In EPUB specification specific file must be the first file in the Container.
http://idpf.org/epub/30/spec/epub30-ocf.html#sec-zip-container-mime
but, rubyzip sorts entries on output, so can't create valid EPUB container.

I've just removed sorting on output. 
