### PR TITLE
Sort ZIP Entries again

### DIFF
--- a/lib/zip/zip_entry_set.rb
+++ b/lib/zip/zip_entry_set.rb
@@ -28,11 +28,11 @@ module Zip
     end
 
     def each(&aProc)
-      @entrySet.values.each(&aProc)
+      entries.each(&aProc)
     end
 
     def entries
-      @entrySet.values
+      @entrySet.values.sort
     end
 
     # deep clone

--- a/test/ziptest.rb
+++ b/test/ziptest.rb
@@ -851,8 +851,23 @@ class ZipEntrySetTest < Test::Unit::TestCase
     assert_equal(ZIP_ENTRIES.size, count)
   end
 
+  def test_each_sorted
+    # @zipEntrySet.each should yield entries in order sorted by name.
+    result = []
+    @zipEntrySet.each_with_index {
+      |entry, index|
+      result << entry
+    }
+    assert_equal(ZIP_ENTRIES.sort, result)
+  end
+
   def test_entries
     assert_equal(ZIP_ENTRIES.sort, @zipEntrySet.entries.sort)
+  end
+
+  def test_entries_sorted
+    # @zipEntrySet.entries should return a list sorted by name.
+    assert_equal(ZIP_ENTRIES.sort, @zipEntrySet.entries)
   end
 
   def test_compound


### PR DESCRIPTION
This ensures that the entries in the zip file's central directory are grouped
together by folder, with each folder's directory entry coming before the
folder's contents, rather than being in the random order dictated by Ruby's
Hash implementation.

Before:

```
  $ unzip -l before.zip
  Archive:  before.zip
    Length      Date    Time    Name
  ---------  ---------- -----   ----
          7  03-11-2011 14:14   fruit/apple
          8  03-11-2011 14:14   fruit/orange
          6  03-11-2011 14:14   fruit/kiwi
          0  03-11-2011 14:14   uuid/5D8976B4-C3B5-4FC6-A9BA-E307173F0064
          0  03-11-2011 14:14   uuid/
          0  03-11-2011 14:14   uuid/B1D55A18-860D-4BE1-BCB3-7DFBCD7C8BC4
          0  03-11-2011 14:14   uuid/E5E1F8F6-60A3-4733-9648-86711E7CD02A
          0  03-11-2011 14:14   fruit/
          8  03-11-2011 14:14   fruit/mango
          0  03-11-2011 14:14   Vegetable/
          0  03-11-2011 14:14   uuid/47FD714B-1A38-46AB-B9EF-0E8B2098D3A5
          0  03-11-2011 14:14   uuid/8B6FD77A-9A4C-4D74-B1E0-5B0EBBF0C3A9
          7  03-11-2011 14:14   Vegetable/celery
          8  03-11-2011 14:14   Vegetable/carrot
          6  03-11-2011 14:14   Vegetable/bean
  ---------                     -------
         50                     15 files
```

After:

```
  $ unzip -l after.zip
  Archive:  after.zip
    Length      Date    Time    Name
  ---------  ---------- -----   ----
          0  03-11-2011 14:15   Vegetable/
          6  03-11-2011 14:15   Vegetable/bean
          8  03-11-2011 14:15   Vegetable/carrot
          7  03-11-2011 14:15   Vegetable/celery
          0  03-11-2011 14:15   fruit/
          7  03-11-2011 14:15   fruit/apple
          6  03-11-2011 14:15   fruit/kiwi
          8  03-11-2011 14:15   fruit/mango
          8  03-11-2011 14:15   fruit/orange
          0  03-11-2011 14:15   uuid/
          0  03-11-2011 14:15   uuid/47FD714B-1A38-46AB-B9EF-0E8B2098D3A5
          0  03-11-2011 14:15   uuid/5D8976B4-C3B5-4FC6-A9BA-E307173F0064
          0  03-11-2011 14:15   uuid/8B6FD77A-9A4C-4D74-B1E0-5B0EBBF0C3A9
          0  03-11-2011 14:15   uuid/B1D55A18-860D-4BE1-BCB3-7DFBCD7C8BC4
          0  03-11-2011 14:15   uuid/E5E1F8F6-60A3-4733-9648-86711E7CD02A
  ---------                     -------
         50                     15 files
```

Similar functionality has been committed before (see commit 74e4512387f6f7820ba6adb750fcc401513efaf7),
but was reverted in commit 963f23c9ed1275291c0394fbf3b1e573db3498e4 because it
breaks things (like EPUB) that require entries to appear in a particular order.

This re-enables sorting by default, but still allows custom ZipEntrySet
implementations to be used when a custom sort order is required.
