### PR TITLE
Unzipping fails when file attributes are 0

### DIFF
--- a/lib/zip/zip_entry.rb
+++ b/lib/zip/zip_entry.rb
@@ -358,7 +358,13 @@ module Zip
         when 012
           @ftype = :symlink
         else
-          @ftype = :unknown
+          #best case guess for whether it is a file or not
+          #Otherwise this would be set to unknown and that entry would never be able to extracted
+          if name_is_directory?
+            @ftype = :directory
+          else
+            @ftype = :file
+          end
         end
       else
         if name_is_directory?


### PR DESCRIPTION
When externalFileAttributes is set to 0, this cases the filetype to get set to :unknown and that file cannot be extracted.  The commit I submitted is probably not the best fix, but should at least be something to bridge the gap.
