### PR TITLE
Fix performance issue on reading zip file with large amount of entries.

### DIFF
--- a/lib/zip/zip_entry_set.rb
+++ b/lib/zip/zip_entry_set.rb
@@ -9,11 +9,15 @@ module Zip
     end
 
     def include?(entry)
-      @entrySet.include?(entry.to_s)
+      @entrySet.include?(to_key(entry))
+    end
+
+    def find_entry(entry)
+      @entrySet[to_key(entry)]
     end
 
     def <<(entry)
-      @entrySet[entry.to_s] = entry
+      @entrySet[to_key(entry)] = entry
     end
     alias :push :<<
 
@@ -24,7 +28,7 @@ module Zip
     alias :length :size
 
     def delete(entry)
-      @entrySet.delete(entry.to_s) ? entry : nil
+      @entrySet.delete(to_key(entry)) ? entry : nil
     end
 
     def each(&aProc)
@@ -46,7 +50,7 @@ module Zip
     end
 
     def parent(entry)
-      @entrySet[entry.parent_as_string]
+      @entrySet[to_key(entry.parent_as_string)]
     end
 
     def glob(pattern, flags = ::File::FNM_PATHNAME|::File::FNM_DOTMATCH)
@@ -58,6 +62,11 @@ module Zip
 #TODO    attr_accessor :auto_create_directories
     protected
     attr_accessor :entrySet
+
+    private
+    def to_key(entry)
+      entry.to_s.sub(/\/$/, "")
+    end
   end
 end
 

--- a/lib/zip/zip_file.rb
+++ b/lib/zip/zip_file.rb
@@ -234,11 +234,8 @@ module Zip
 
     # Searches for entry with the specified name. Returns nil if
     # no entry is found. See also get_entry
-    def find_entry(entry)
-      @entrySet.detect {
-        |e|
-        e.name.sub(/\/$/, "") == entry.to_s.sub(/\/$/, "")
-      }
+    def find_entry(entry_name)
+      @entrySet.find_entry(entry_name)
     end
 
     # Searches for an entry just as find_entry, but throws Errno::ENOENT
@@ -280,7 +277,7 @@ module Zip
 
     def check_entry_exists(entryName, continueOnExistsProc, procedureName)
       continueOnExistsProc ||= proc { Zip.options[:continue_on_exists_proc] }
-      if @entrySet.detect { |e| e.name == entryName }
+      if @entrySet.include?(entryName)
         if continueOnExistsProc.call
           remove get_entry(entryName)
         else

--- a/test/ziptest.rb
+++ b/test/ziptest.rb
@@ -857,21 +857,15 @@ class ZipEntrySetTest < Test::Unit::TestCase
 
   def test_parent
     entries = [
-      ZipEntry.new("zf.zip", "a"),
       ZipEntry.new("zf.zip", "a/"),
-      ZipEntry.new("zf.zip", "a/b"),
       ZipEntry.new("zf.zip", "a/b/"),
-      ZipEntry.new("zf.zip", "a/b/c"),
       ZipEntry.new("zf.zip", "a/b/c/")
     ]
     entrySet = ZipEntrySet.new(entries)
 
     assert_equal(nil, entrySet.parent(entries[0]))
-    assert_equal(nil, entrySet.parent(entries[1]))
+    assert_equal(entries[0], entrySet.parent(entries[1]))
     assert_equal(entries[1], entrySet.parent(entries[2]))
-    assert_equal(entries[1], entrySet.parent(entries[3]))
-    assert_equal(entries[3], entrySet.parent(entries[4]))
-    assert_equal(entries[3], entrySet.parent(entries[5]))
   end
 
   def test_glob


### PR DESCRIPTION
I recently came cross reading/writing zip files with large amount small files, and found Zip::ZipFile.find_entry is really big performance bottom-neck for my app through profiling. This pull request try to resolve this problem by making zip entry lookup in Zip::ZipEntrySet as a hash lookup (O(n) -> O(1)). A side effect of this change is that now in Zip::ZipEntrySet entries with name "a_directory" and "a_directory/" will be stored as one entry. I guess that is fine because file and directory with same name can not co-exists in a zip file anyway.

I did a simple experiment, given a zip file with 35160 directories and files, execute following code under ruby 1.9.2, MacOSX 10.7:

``` ruby
zipfile = Zip::ZipFile.open("./the_zip_file", Zip::ZipFile::CREATE)

zipfile.each do |entry|
  if entry.ftype == :file
    entry.get_input_stream { |s| s.readlines }
  end
end
```

Before applying the patch:

``` console
ruby read_test.rb  1340.08s user 13.23s system 100% cpu 22:28.38 total
```

After:

``` console
ruby read_test.rb  28.48s user 0.77s system 100% cpu 29.203 total
```
