### PR TITLE
ZipEntry modification time isn’t saved in zip file

### DIFF
--- a/lib/zip/zip_output_stream.rb
+++ b/lib/zip/zip_output_stream.rb
@@ -81,13 +81,16 @@ module Zip
     # +entry+ can be a ZipEntry object or a string.
     def put_next_entry(entryname, comment = nil, extra = nil, compression_method = ZipEntry::DEFLATED,  level = Zlib::DEFAULT_COMPRESSION)
       raise ZipError, "zip stream is closed" if @closed
-      new_entry = ZipEntry.new(@fileName, entryname.to_s)
-      new_entry.unix_perms = entryname.unix_perms if entryname.respond_to? :unix_perms
+      if entryname.kind_of?(ZipEntry)
+        new_entry = entryname
+      else
+        new_entry = ZipEntry.new(@fileName, entryname.to_s)
+      end
       new_entry.comment = comment if !comment.nil?
       if (!extra.nil?)
         new_entry.extra = ZipExtraField === extra ? extra : ZipExtraField.new(extra.to_s)
       end
-      new_entry.compression_method = compression_method
+      new_entry.compression_method = compression_method if !compression_method.nil?
       init_next_entry(new_entry, level)
       @currentEntry = new_entry
     end


### PR DESCRIPTION
I have the following code in my app. It bundles a bunch of files into a zip file:

``` ruby
f = File.new("assets/files/#{file_name}", 'w')
Zip::ZipOutputStream.open(f.path) do |zos|
  files.each do |file|
    zip_entry = Zip::ZipEntry.new(zos, file.name, "", "", 0, 0, Zip::ZipEntry::DEFLATED, 0, DOSTime.at(file.mtime))
    zos.put_next_entry(zip_entry)
    zos.print IO.read(file.path)
  end
  zos.close
end
```

It works well, but I’d like the zip archive’s files modification timestamps to match the files modification timestamps on my server. Instead, the files modification timestamps match the zip archive creation timestamp:

``` bash
~/Downloads% unzip -l zip_file.zip
  Length     Date   Time    Name
 --------    ----   ----    ----
    31934  03-27-12 11:20   config/locales/app/de.yml
     4284  03-27-12 11:20   config/locales/defaults/de.yml
 --------                   -------
    36218                   2 files
```

I had a look at rubyzip’s source code and this is due to the fact that `ZipEntry`’s attributes aren’t saved at all in `zos.put_next_entry(zip_entry)`.

The pull request attached adds a failing test, and fix this issue.
