### PR TITLE
Properly commit when the comment is the only thing changed.

### DIFF
--- a/lib/zip/zip_file.rb
+++ b/lib/zip/zip_file.rb
@@ -73,6 +73,7 @@ module Zip
       end
       @create = create
       @storedEntries = @entrySet.dup
+      @storedComment = @comment
       @restore_ownership = false
       @restore_permissions = false
       @restore_times = true
@@ -229,7 +230,7 @@ module Zip
       @entrySet.each do |e|
         return true if e.dirty
       end
-      @entrySet != @storedEntries || @create == ZipFile::CREATE
+      @comment != @storedComment || @entrySet != @storedEntries || @create == ZipFile::CREATE
     end
 
     # Searches for entry with the specified name. Returns nil if

--- a/test/ziptest.rb
+++ b/test/ziptest.rb
@@ -1452,6 +1452,14 @@ class ZipFileTest < Test::Unit::TestCase
     end
   end
 
+  def test_changeComment
+    ZipFile.open(TEST_ZIP.zip_name) do |zf|
+      zf.comment = "my changed comment"
+    end
+    zfRead = ZipFile.open(TEST_ZIP.zip_name)
+    assert_equal("my changed comment", zfRead.comment)
+  end
+
   private
   def assert_contains(zf, entryName, filename = entryName)
     assert(zf.entries.detect { |e| e.name == entryName} != nil, "entry #{entryName} not in #{zf.entries.join(', ')} in zip file #{zf}")


### PR DESCRIPTION
Right now, the only way to change the comment on a zip file is to actually change the contents of the zip file in some way. This pull request adds a `@storedComment` variable (similar to `@storedEntries`) and updates the `commit_required?` method to check for a changed comment. Test included.
