### PR TITLE
bugfix: get correct size for utf8 strings

### DIFF
--- a/lib/zip/deflater.rb
+++ b/lib/zip/deflater.rb
@@ -11,7 +11,7 @@ module Zip
     def << (data)
       val = data.to_s
       @crc = Zlib::crc32(val, @crc)
-      @size += val.size
+      @size += val.bytesize
       @outputStream << @zlibDeflater.deflate(data)
     end
 

--- a/lib/zip/pass_thru_compressor.rb
+++ b/lib/zip/pass_thru_compressor.rb
@@ -10,7 +10,7 @@ module Zip
     def << (data)
       val = data.to_s
       @crc = Zlib::crc32(val, @crc)
-      @size += val.size
+      @size += val.bytesize
       @outputStream << val
     end
 


### PR DESCRIPTION
Zip created from utf8 strings with accents were truncated, this appears to fix the problem for me.
I wanted to add a test but the test folder frightened me xD
