### PR TITLE
Added Zip::ZipFile.open_buffer

### DIFF
--- a/lib/zip/zip_file.rb
+++ b/lib/zip/zip_file.rb
@@ -103,6 +103,24 @@ module Zip
         zf.write_buffer
       end
 
+      # Like #open, but reads zip archive contents from a String or open IO
+      # stream, and outputs data to a buffer.
+      # (This can be used to extract data from a 
+      # downloaded zip archive without first saving it to disk.)
+      def open_buffer(io)
+        zf = ZipFile.new('',true,true)
+        if io.is_a? IO
+          zf.read_from_stream(io)
+        elsif io.is_a? String
+          require 'stringio'
+          zf.read_from_stream(StringIO.new(io))
+        else
+          raise "Zip::ZipFile.open_buffer expects an argument of class String or IO. Found: #{io.class}"
+        end
+        yield zf
+        zf.write_buffer
+      end
+
       # Iterates over the contents of the ZipFile. This is more efficient
       # than using a ZipInputStream since this methods simply iterates
       # through the entries in the central directory structure in the archive


### PR DESCRIPTION
It's happened several times now that I have written Ruby scripts which automatically download ZIP files (perhaps from some kind of data feed, etc) and want to extract a file from the downloaded ZIP, without saving it to disk first. I just discovered that it is possible to do so using an optional argument to Zip::ZipInputStream, but I'd rather use the nice, high-level interface of ZipFile and ZipFileSystem. I figure there must be a lot of other people who want to do the same thing. Have a look at this added method, and see if you think it is worth adding to Zip::ZipFile... or perhaps you can come up with a better way to add the same functionality?
