### PR TITLE
Averting of compression method override

### DIFF
--- a/lib/zip/zip_entry.rb
+++ b/lib/zip/zip_entry.rb
@@ -543,7 +543,7 @@ module Zip
       if @ftype == :directory
         aZipOutputStream.put_next_entry(self)
       elsif @filepath
-        aZipOutputStream.put_next_entry(self)
+        aZipOutputStream.put_next_entry(self, nil, nil, nil)
         get_input_stream { |is| IOExtras.copy_stream(aZipOutputStream, is) }
       else
         aZipOutputStream.copy_raw_entry(self)


### PR DESCRIPTION
Example of code:

```
::Zip::ZipFile.open("path_to.zip", ::Zip::ZipFile::CREATE) { |zip_content|
        entry_path = "test.txt"
        zip_entry = ::Zip::ZipEntry.new("", entry_path, "", "", 0, 0,::Zip::ZipEntry::STORED)
        zip_content.add zip_entry, entry
      end
  }
```

Without this fix file "test.txt" will be always compressed (using DEFLATED compression method)
