### PR TITLE
Add support for reading Zip64 files

### DIFF
--- a/lib/zip/zip_entry.rb
+++ b/lib/zip/zip_entry.rb
@@ -270,6 +270,7 @@ module Zip
           @extra = ZipExtraField.new(extra)
         end
       end
+      fix_zip64_sizes!
       @local_header_size = calculate_local_header_size
     end
 
@@ -370,6 +371,7 @@ module Zip
           @ftype = :file
         end
       end
+      fix_zip64_sizes!
       @local_header_size = calculate_local_header_size
     end
 
@@ -404,6 +406,13 @@ module Zip
         FileUtils::chmod(@unix_perms & unix_perms_mask, destPath) if (@restore_permissions && @unix_perms)
         FileUtils::chown(@unix_uid, @unix_gid, destPath) if (@restore_ownership && @unix_uid && @unix_gid && Process::egid == 0)
         # File::utimes()
+      end
+    end
+
+    def fix_zip64_sizes! #:nodoc:all
+      if zip64 = @extra["Zip64"]
+        @size = zip64.original_size
+        @compressed_size = zip64.compressed_size
       end
     end
 

--- a/lib/zip/zip_extra_field.rb
+++ b/lib/zip/zip_extra_field.rb
@@ -126,6 +126,35 @@ module Zip
       end
     end
 
+    # Info-ZIP Extra for Zip64 size
+    class Zip64 < Generic
+      HEADER_ID = "\001\000"
+      register_map
+
+      def initialize(binstr = nil)
+        @original_size = nil
+        @compressed_size = nil
+        @relative_header_offset = nil
+        @disk_start_number = nil
+        binstr and merge(binstr)
+      end
+      attr_accessor :original_size, :compressed_size, :relative_header_offset, :disk_start_number
+
+      def merge(binstr)
+        return if binstr.empty?
+        id, size, @original_size, @compressed_size, @relative_header_offset, @disk_start_number = binstr.to_s.unpack("vvQQQV")
+      end
+
+      def pack_for_local
+        return "" unless @original_size && @compressed_sie && @relative_header_offset && @disk_start_number
+        [1, 16, @original_size, @compressed_size, @relative_header_offset, @disk_start_number].pack("vvQQQV")
+      end
+
+      def pack_for_c_dir
+        pack_for_local
+      end
+    end
+
     ## start main of ZipExtraField < Hash
     def initialize(binstr = nil)
       binstr and merge(binstr)


### PR DESCRIPTION
Without this patch, rubyzip mistakenly believes that the files stored with Zip64 are of size 0xFFFFFFFF (4294967295). This can cause various problems depending on the archive.

I've been seeing more and more zips that do not actually have large files inside, but still have the size data stored in the 64-bit format. 

This is my first attempt to submit a patch to this project - can you give me some advice on what sort of testing is recommended for a commit like this?
