### PR TITLE
Fixed conditional in Zip::File.open_buffer()

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -120,7 +120,7 @@ module Zip
           raise "Zip::ZipFile.open_buffer expects an argument of class String or IO. Found: #{io.class}"
         end
         zf = ::Zip::File.new('', true, true)
-        if io.is_a(::String)
+        if io.is_a?(::String)
           require 'stringio'
           io = ::StringIO.new(io)
         end


### PR DESCRIPTION
It required it to be be both an IO _and_ a String, which isn't exactly possible.
