### PR TITLE
Fix overriding constant with other ziplibs

### DIFF
--- a/lib/zip/constants.rb
+++ b/lib/zip/constants.rb
@@ -1,5 +1,6 @@
 module Zip
-  VERSION = '0.9.7'
+  VERSION ||= '0.9.7'
+
   RUBY_MINOR_VERSION = RUBY_VERSION.split(".")[1].to_i
   RUNNING_ON_WINDOWS = RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/i
 


### PR DESCRIPTION
This is causing warnings with other zip libraries like zipruby otherwise, since this one also defines the ZIP::VERSION.
