### PR TITLE
Zip::InputStream#read(number_of_bytes) should return nil at EOF.

### DIFF
--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -33,9 +33,12 @@ module Zip
                  sysread(number_of_bytes, buf)
                end
 
-        @pos += tbuf.length
+        if tbuf.nil? || tbuf.length == 0
+          return nil if number_of_bytes
+          return ""
+        end
 
-        return nil unless tbuf
+        @pos += tbuf.length
 
         if buf
           buf.replace(tbuf)

--- a/test/ziptest.rb
+++ b/test/ziptest.rb
@@ -498,6 +498,16 @@ class ZipInputStreamTest < Test::Unit::TestCase
     end
   end
 
+  def test_read_with_number_of_bytes_returns_nil_at_eof
+    ::Zip::InputStream.open(TestZipFile::TEST_ZIP2.zip_name) do |zis|
+      entry = zis.get_next_entry # longAscii.txt
+      zis.read(entry.size)
+      assert_equal(true, zis.eof?)
+      assert_nil(zis.read(1))
+      assert_nil(zis.read(1))
+    end
+  end
+
   def test_rewind
     ::Zip::InputStream.open(TestZipFile::TEST_ZIP2.zip_name) {
       |zis|


### PR DESCRIPTION
Previously it would return an empty string the first time, then raise on subsequent calls.
