### PR TITLE
Add entry arguments to Zip::File#get_output_stream. Fixes rubyzip/rubyzip#100

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -224,11 +224,18 @@ module Zip
       get_entry(entry).get_input_stream(&aProc)
     end
 
-    # Returns an output stream to the specified entry. If a block is passed
-    # the stream object is passed to the block and the stream is automatically
-    # closed afterwards just as with ruby's builtin File.open method.
-    def get_output_stream(entry, permissionInt = nil, &aProc)
-      newEntry = entry.kind_of?(Entry) ? entry : Entry.new(@name, entry.to_s)
+    # Returns an output stream to the specified entry. If entry is not an instance
+    # of Zip::Entry, a new Zip::Entry will be initialized using the arguments
+    # specified. If a block is passed the stream object is passed to the block and 
+    # the stream is automatically closed afterwards just as with ruby's builtin 
+    # File.open method.
+    def get_output_stream(entry, permissionInt = nil, comment = nil, extra = nil, compressed_size = nil, crc = nil, compression_method = nil, size = nil, time = nil,  &aProc)
+      newEntry =
+        if entry.kind_of?(Entry)
+          entry
+        else
+          Entry.new(@name, entry.to_s, comment, extra, compressed_size, crc, compression_method, size, time)
+        end
       if newEntry.directory?
         raise ArgumentError,
               "cannot open stream to directory entry - '#{newEntry}'"

--- a/test/ziptest.rb
+++ b/test/ziptest.rb
@@ -1231,6 +1231,20 @@ class ZipFileTest < Test::Unit::TestCase
       assert_equal(entryCount+1, zf.size)
       assert_equal("Putting stuff in data/generated/empty.txt", zf.read("data/generated/empty.txt"))
 
+      custom_entry_args = [ZipEntryTest::TEST_COMMENT, ZipEntryTest::TEST_EXTRA, ZipEntryTest::TEST_COMPRESSED_SIZE, ZipEntryTest::TEST_CRC, ::Zip::Entry::STORED, ZipEntryTest::TEST_SIZE, ZipEntryTest::TEST_TIME]
+      zf.get_output_stream('entry_with_custom_args.txt', nil, *custom_entry_args) {
+        |os|
+        os.write "Some data"
+      }
+      assert_equal(entryCount+2, zf.size)
+      entry = zf.get_entry('entry_with_custom_args.txt')
+      assert_equal(custom_entry_args[0], entry.comment)
+      assert_equal(custom_entry_args[2], entry.compressed_size)
+      assert_equal(custom_entry_args[3], entry.crc)
+      assert_equal(custom_entry_args[4], entry.compression_method)
+      assert_equal(custom_entry_args[5], entry.size)
+      assert_equal(custom_entry_args[6], entry.time)
+
       zf.get_output_stream('entry.bin') {
         |os|
         os.write(::File.open('data/generated/5entry.zip', 'rb').read)
@@ -1239,7 +1253,7 @@ class ZipFileTest < Test::Unit::TestCase
 
     ::Zip::File.open(TEST_ZIP.zip_name) {
       |zf|
-      assert_equal(entryCount+2, zf.size)
+      assert_equal(entryCount+3, zf.size)
       assert_equal("Putting stuff in newEntry.txt", zf.read("newEntry.txt"))
       assert_equal("Putting stuff in data/generated/empty.txt", zf.read("data/generated/empty.txt"))
       assert_equal(File.open('data/generated/5entry.zip', 'rb').read, zf.read("entry.bin"))


### PR DESCRIPTION
I could'nt understand how to test `entry.extra` equality, but it seems to me that it isn't tested in the other tests.

Please check if the documentation I added is correct, my english is bad.
