### PR TITLE
Use current version number in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you have issues with any third-party gems what required rubyzip you can use n
 
 ```ruby
 # Place this line before your library or on the head of your Gemfile
-gem 'rubyzip', '< 1.0.0'
+gem 'rubyzip', '~> 1.1.0'
 ```
 
 ## Requirements


### PR DESCRIPTION
Version number on the README is out of date. It is actually instructing users to use a version below `1.0.0` even though there is a `1.0.0` and `1.1.0` release.
