### PR TITLE
Add Ruby 2.1.0 to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - ruby-head
   - rbx
 matrix:
@@ -19,8 +20,5 @@ before_script:
   - sudo apt-get install -qq zip unzip
   - echo `whereis zip`
   - echo `whereis unzip`
-branches:
-  only:
-    - master
 allow_failures:
   - rvm: ruby-head


### PR DESCRIPTION
1 Explicitly added the released 2.1.0 Ruby version
2. Removed branch restriction on Travis
