### PR TITLE
Freeze static strings used when writing a zipfile

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -45,13 +45,13 @@ module Zip
     end
 
     def check_name(name)
-      if name.start_with?('/')
+      if name.start_with?('/'.freeze)
         raise ::Zip::EntryNameError, "Illegal ZipEntry name '#{name}', name must not start with /"
       end
     end
 
     def initialize(*args)
-      name = args[1] || ''
+      name = args[1] || ''.freeze
       check_name(name)
 
       set_default_vars_values
@@ -59,8 +59,8 @@ module Zip
 
       @zipfile            = args[0] || ''
       @name               = name
-      @comment            = args[2] || ''
-      @extra              = args[3] || ''
+      @comment            = args[2] || ''.freeze
+      @extra              = args[3] || ''.freeze
       @compressed_size    = args[4] || 0
       @crc                = args[5] || 0
       @compression_method = args[6] || ::Zip::Entry::DEFLATED
@@ -104,7 +104,7 @@ module Zip
     end
 
     def name_is_directory? #:nodoc:all
-      @name.end_with?('/')
+      @name.end_with?('/'.freeze)
     end
 
     def local_entry_offset #:nodoc:all
@@ -251,7 +251,7 @@ module Zip
     end
 
     def pack_local_entry
-      zip64 = @extra['Zip64']
+      zip64 = @extra['Zip64'.freeze]
       [::Zip::LOCAL_ENTRY_SIGNATURE,
        @version_needed_to_extract, # version needed to extract
        @gp_flags, # @gp_flags                  ,
@@ -262,7 +262,7 @@ module Zip
        (zip64 && zip64.compressed_size) ? 0xFFFFFFFF : @compressed_size,
        (zip64 && zip64.original_size) ? 0xFFFFFFFF : @size,
        name_size,
-       @extra ? @extra.local_size : 0].pack('VvvvvvVVVvv')
+       @extra ? @extra.local_size : 0].pack('VvvvvvVVVvv'.freeze)
     end
 
     def write_local_entry(io, rewrite = false) #:nodoc:all
@@ -298,7 +298,7 @@ module Zip
         @local_header_offset,
         @name,
         @extra,
-        @comment = buf.unpack('VCCvvvvvVVVvvvvvVV')
+        @comment = buf.unpack('VCCvvvvvVVVvvvvvVV'.freeze)
     end
 
     def set_ftype_from_c_dir_entry
@@ -362,7 +362,7 @@ module Zip
       unpack_c_dir_entry(static_sized_fields_buf)
       check_c_dir_entry_signature
       set_time(@last_mod_date, @last_mod_time)
-      @name = io.read(@name_length).gsub('\\', '/')
+      @name = io.read(@name_length).gsub('\\'.freeze, '/'.freeze)
       read_c_dir_extra_field(io)
       @comment = io.read(@comment_length)
       check_c_dir_entry_comment_size
@@ -408,7 +408,7 @@ module Zip
     end
 
     def pack_c_dir_entry
-      zip64 = @extra['Zip64']
+      zip64 = @extra['Zip64'.freeze]
       [
         @header_signature,
         @version, # version of encoding software
@@ -431,7 +431,7 @@ module Zip
         @name,
         @extra,
         @comment
-      ].pack('VCCvvvvvVVVvvvvvVV')
+      ].pack('VCCvvvvvVVVvvvvvVV'.freeze)
     end
 
     def write_c_dir_entry(io) #:nodoc:all
@@ -634,7 +634,7 @@ module Zip
     # apply missing data from the zip64 extra information field, if present
     # (required when file sizes exceed 2**32, but can be used for all files)
     def parse_zip64_extra(for_local_header) #:nodoc:all
-      if zip64 = @extra['Zip64']
+      if zip64 = @extra['Zip64'.freeze]
         if for_local_header
           @size, @compressed_size = zip64.parse(@size, @compressed_size)
         else

--- a/lib/zip/entry_set.rb
+++ b/lib/zip/entry_set.rb
@@ -77,7 +77,7 @@ module Zip
 
     private
     def to_key(entry)
-      entry.to_s.sub(/\/$/, '')
+      entry.to_s.sub(/\/$/, ''.freeze)
     end
   end
 end

--- a/lib/zip/extra_field.rb
+++ b/lib/zip/extra_field.rb
@@ -64,13 +64,13 @@ module Zip
     end
 
     def to_local_bin
-      ordered_values.map { |v| v.to_local_bin.force_encoding('BINARY') }.join
+      ordered_values.map { |v| v.to_local_bin.force_encoding('BINARY'.freeze) }.join
     end
 
     alias :to_s :to_local_bin
 
     def to_c_dir_bin
-      ordered_values.map { |v| v.to_c_dir_bin.force_encoding('BINARY') }.join
+      ordered_values.map { |v| v.to_c_dir_bin.force_encoding('BINARY'.freeze) }.join
     end
 
     def c_dir_size

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -258,7 +258,7 @@ module Zip
     # Convenience method for adding the contents of a file to the archive
     def add(entry, src_path, &continue_on_exists_proc)
       continue_on_exists_proc ||= proc { ::Zip.continue_on_exists_proc }
-      check_entry_exists(entry, continue_on_exists_proc, "add")
+      check_entry_exists(entry, continue_on_exists_proc, "add".freeze)
       new_entry = entry.kind_of?(::Zip::Entry) ? entry : ::Zip::Entry.new(@name, entry.to_s)
       new_entry.gather_fileinfo_from_srcpath(src_path)
       new_entry.dirty = true


### PR DESCRIPTION
As mentioned in rubyzip/rubyzip#130, `#freeze` many static Strings in `entry[_set].rb`, `extra_field.rb`, and `file.rb` for better performance in ruby >= 2.1. Performance should not be hindered in ruby < 2.1.

Performance is improved by reducing the number of String allocations that need to occur, thus reducing GC time. Here is a before and after:

### master

```
$ ruby rubyzip_write.rb | grep "String"
                       sourcefile                          sourceline       class       count
---------------------------------------------------------  ----------  ---------------  -----
/Users/srawlins/code/rubyzip/lib/zip/entry_set.rb                  80  String           10050
/Users/srawlins/code/rubyzip/lib/zip/extra_field.rb                67  String            7000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     365  String            5044
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     265  String            4000
/Users/srawlins/code/rubyzip/lib/zip/entry_set.rb                  21  String            3840
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     107  String            3000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                      62  String            2000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                      48  String            2000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     254  String            2000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     273  String            2000
/Users/srawlins/code/rubyzip/lib/zip/deflater.rb                   20  String            2000
/Users/srawlins/code/rubyzip/lib/zip/extra_field.rb                73  String            2000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     434  String            2000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                      63  String            2000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     275  String            1920
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     458  String            1000
/Users/srawlins/code/rubyzip/lib/zip/file.rb                      261  String            1000
/Users/srawlins/code/rubyzip/lib/zip/central_directory.rb          29  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     360  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     301  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     355  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     367  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     637  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     181  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                      54  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     513  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     378  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     411  String            1000
...
# totalling 63854 allocations from these locations
```

### this pull request

```
$ ruby rubyzip_write.rb | grep "String"
                       sourcefile                          sourceline       class       count
---------------------------------------------------------  ----------  ---------------  -----
/Users/srawlins/code/rubyzip/lib/zip/extra_field.rb                67  String            7000
/Users/srawlins/code/rubyzip/lib/zip/entry_set.rb                  80  String            5050
/Users/srawlins/code/rubyzip/lib/zip/entry_set.rb                  21  String            3840
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     365  String            3044
/Users/srawlins/code/rubyzip/lib/zip/extra_field.rb                73  String            2000
/Users/srawlins/code/rubyzip/lib/zip/deflater.rb                   20  String            2000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     273  String            2000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     265  String            2000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     275  String            1920
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     378  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     434  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     458  String            1000
/Users/srawlins/code/rubyzip/lib/zip/central_directory.rb          29  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     513  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     367  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     360  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     181  String            1000
/Users/srawlins/code/rubyzip/lib/zip/entry.rb                     355  String            1000
...
# totalling 37854 allocations from these locations
```

GC time is down too:

```
GC 16 invokes.
Index    Invoke Time(sec)    Use Size(byte)    Total Size(byte)    Total Object           GC Time(ms)
    1               0.220           1328360             3688320           92208    4.9319999999999915
    2               1.118          19905120            37389120          934728   86.0360000000000013
    3               1.686          19906480            37389120          934728   35.1129999999999498
```

vs

```
GC 16 invokes.
Index    Invoke Time(sec)    Use Size(byte)    Total Size(byte)    Total Object           GC Time(ms)
    1               0.221           1328360             3688320           92208    5.6819999999999923
    2               1.032          15745440            30094080          752352   77.9510000000001070
    3               1.506          15746800            30094080          752352   30.0819999999999438
```