### PR TITLE
File.exists? -> File.exist?

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -570,7 +570,7 @@ module Zip
     end
 
     def create_file(dest_path, continue_on_exists_proc = proc { Zip.continue_on_exists_proc })
-      if ::File.exists?(dest_path) && !yield(self, dest_path)
+      if ::File.exist?(dest_path) && !yield(self, dest_path)
         raise ::Zip::DestinationFileExistsError,
               "Destination '#{dest_path}' already exists"
       end
@@ -588,7 +588,7 @@ module Zip
 
     def create_directory(dest_path)
       return if ::File.directory?(dest_path)
-      if ::File.exists?(dest_path)
+      if ::File.exist?(dest_path)
         if block_given? && yield(self, dest_path)
           ::FileUtils::rm_f dest_path
         else

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -70,7 +70,7 @@ module Zip
       @comment = ''
       @create  = create
       case
-      when !buffer && ::File.exists?(file_name)
+      when !buffer && ::File.exist?(file_name)
         @create = nil
         @exist_file_perms = ::File.stat(file_name).mode
         ::File.open(name, 'rb') do |f|
@@ -194,7 +194,7 @@ module Zip
 
       # Splits an archive into parts with segment size
       def split(zip_file_name, segment_size = MAX_SEGMENT_SIZE, delete_zip_file = true, partial_zip_file_name = nil)
-        raise Error, "File #{zip_file_name} not found" unless ::File.exists?(zip_file_name)
+        raise Error, "File #{zip_file_name} not found" unless ::File.exist?(zip_file_name)
         raise Errno::ENOENT, zip_file_name unless ::File.readable?(zip_file_name)
         zip_file_size = ::File.size(zip_file_name)
         segment_size  = get_segment_size_for_split(segment_size)

--- a/test/file_extract_directory_test.rb
+++ b/test/file_extract_directory_test.rb
@@ -20,7 +20,7 @@ class ZipFileExtractDirectoryTest < MiniTest::Unit::TestCase
     super
 
     Dir.rmdir(TEST_OUT_NAME) if File.directory? TEST_OUT_NAME
-    File.delete(TEST_OUT_NAME) if File.exists? TEST_OUT_NAME
+    File.delete(TEST_OUT_NAME) if File.exist? TEST_OUT_NAME
   end
 
   def test_extractDirectory

--- a/test/file_extract_test.rb
+++ b/test/file_extract_test.rb
@@ -7,7 +7,7 @@ class ZipFileExtractTest < MiniTest::Unit::TestCase
 
   def setup
     super
-    ::File.delete(EXTRACTED_FILENAME) if ::File.exists?(EXTRACTED_FILENAME)
+    ::File.delete(EXTRACTED_FILENAME) if ::File.exist?(EXTRACTED_FILENAME)
   end
 
   def test_extract
@@ -15,7 +15,7 @@ class ZipFileExtractTest < MiniTest::Unit::TestCase
         |zf|
       zf.extract(ENTRY_TO_EXTRACT, EXTRACTED_FILENAME)
 
-      assert(File.exists?(EXTRACTED_FILENAME))
+      assert(File.exist?(EXTRACTED_FILENAME))
       AssertEntry::assert_contents(EXTRACTED_FILENAME,
                                    zf.get_input_stream(ENTRY_TO_EXTRACT) { |is| is.read })
 
@@ -25,7 +25,7 @@ class ZipFileExtractTest < MiniTest::Unit::TestCase
       entry = zf.get_entry(ENTRY_TO_EXTRACT)
       entry.extract(EXTRACTED_FILENAME)
 
-      assert(File.exists?(EXTRACTED_FILENAME))
+      assert(File.exist?(EXTRACTED_FILENAME))
       AssertEntry::assert_contents(EXTRACTED_FILENAME,
                                    entry.get_input_stream() { |is| is.read })
 
@@ -84,7 +84,7 @@ class ZipFileExtractTest < MiniTest::Unit::TestCase
       zf.extract(nonEntry, outFile)
       zf.close
     }
-    assert(!File.exists?(outFile))
+    assert(!File.exist?(outFile))
   end
 
 end

--- a/test/file_split_test.rb
+++ b/test/file_split_test.rb
@@ -13,10 +13,10 @@ class ZipFileSplitTest < MiniTest::Unit::TestCase
 
   def teardown
     File.delete(TEST_ZIP.zip_name)
-    File.delete(UNSPLITTED_FILENAME) if File.exists?(UNSPLITTED_FILENAME)
+    File.delete(UNSPLITTED_FILENAME) if File.exist?(UNSPLITTED_FILENAME)
 
     Dir["#{TEST_ZIP.zip_name}.*"].each do |zip_file_name|
-      File.delete(zip_file_name) if File.exists?(zip_file_name)
+      File.delete(zip_file_name) if File.exist?(zip_file_name)
     end
   end
 
@@ -40,7 +40,7 @@ class ZipFileSplitTest < MiniTest::Unit::TestCase
       ::Zip::File.open(UNSPLITTED_FILENAME) do |zf|
         zf.extract(ENTRY_TO_EXTRACT, EXTRACTED_FILENAME)
 
-        assert(File.exists?(EXTRACTED_FILENAME))
+        assert(File.exist?(EXTRACTED_FILENAME))
         AssertEntry::assert_contents(EXTRACTED_FILENAME,
                                      zf.get_input_stream(ENTRY_TO_EXTRACT) { |is| is.read })
 
@@ -50,7 +50,7 @@ class ZipFileSplitTest < MiniTest::Unit::TestCase
         entry = zf.get_entry(ENTRY_TO_EXTRACT)
         entry.extract(EXTRACTED_FILENAME)
 
-        assert(File.exists?(EXTRACTED_FILENAME))
+        assert(File.exist?(EXTRACTED_FILENAME))
         AssertEntry::assert_contents(EXTRACTED_FILENAME,
                                      entry.get_input_stream() { |is| is.read })
 

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -92,7 +92,7 @@ class ZipFileTest < MiniTest::Unit::TestCase
   def test_add
     srcFile = "test/data/file2.txt"
     entryName = "newEntryName.rb"
-    assert(::File.exists?(srcFile))
+    assert(::File.exist?(srcFile))
     zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
     zf.add(entryName, srcFile)
     zf.close
@@ -111,7 +111,7 @@ class ZipFileTest < MiniTest::Unit::TestCase
     srcFile = "test/data/file2.txt"
     entryName = "newEntryName.rb"
     assert_equal(::File.stat(srcZip).mode, 0100664)
-    assert(::File.exists?(srcZip))
+    assert(::File.exist?(srcZip))
     zf = ::Zip::File.new(srcZip, ::Zip::File::CREATE)
     zf.add(entryName, srcFile)
     zf.close
@@ -529,7 +529,7 @@ class ZipFileTest < MiniTest::Unit::TestCase
   private
   def assert_contains(zf, entryName, filename = entryName)
     assert(zf.entries.detect { |e| e.name == entryName } != nil, "entry #{entryName} not in #{zf.entries.join(', ')} in zip file #{zf}")
-    assert_entryContents(zf, entryName, filename) if File.exists?(filename)
+    assert_entryContents(zf, entryName, filename) if File.exist?(filename)
   end
 
   def assert_not_contains(zf, entryName)

--- a/test/gentestfiles.rb
+++ b/test/gentestfiles.rb
@@ -50,7 +50,7 @@ class TestFiles
     end
 
     def ensure_dir(name)
-      if File.exists?(name)
+      if File.exist?(name)
         return if File.stat(name).directory?
         File.delete(name)
       end

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -9,7 +9,7 @@ class ZipSettingsTest < MiniTest::Unit::TestCase
     super
 
     Dir.rmdir(TEST_OUT_NAME) if File.directory? TEST_OUT_NAME
-    File.delete(TEST_OUT_NAME) if File.exists? TEST_OUT_NAME
+    File.delete(TEST_OUT_NAME) if File.exist? TEST_OUT_NAME
   end
 
   def open_zip(&aProc)
@@ -66,6 +66,6 @@ class ZipSettingsTest < MiniTest::Unit::TestCase
   private
   def assert_contains(zf, entryName, filename = entryName)
     assert(zf.entries.detect { |e| e.name == entryName } != nil, "entry #{entryName} not in #{zf.entries.join(', ')} in zip file #{zf}")
-    assert_entryContents(zf, entryName, filename) if File.exists?(filename)
+    assert_entryContents(zf, entryName, filename) if File.exist?(filename)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -200,7 +200,7 @@ module CommonZipFileFixture
   TEST_ZIP.zip_name = "test/data/generated/5entry_copy.zip"
 
   def setup
-    File.delete(EMPTY_FILENAME) if File.exists?(EMPTY_FILENAME)
+    File.delete(EMPTY_FILENAME) if File.exist?(EMPTY_FILENAME)
     FileUtils.cp(TestZipFile::TEST_ZIP2.zip_name, TEST_ZIP.zip_name)
   end
 end

--- a/test/zip64_full_test.rb
+++ b/test/zip64_full_test.rb
@@ -9,7 +9,7 @@ if ENV['FULL_ZIP64_TEST']
 
   class Zip64FullTest < MiniTest::Unit::TestCase
     def prepareTestFile(test_filename)
-      File.delete(test_filename) if File.exists?(test_filename)
+      File.delete(test_filename) if File.exist?(test_filename)
       return test_filename
     end
 


### PR DESCRIPTION
According to ruby 2.1, when running the tests:

```
/Users/srawlins/code/rubyzip/test/gentestfiles.rb:53: warning: File.exists? is a deprecated
name, use File.exist? instead
```

This pull request does that.
