### PR TITLE
Updated on_success_replace to not close, ie. delete

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -400,8 +400,8 @@ module Zip
     end
 
     def on_success_replace
+      tmpfile = create_binary_tempfile
       begin
-        tmpfile      = create_binary_tempfile
         tmp_filename = tmpfile.path
         if yield tmp_filename
           ::File.rename(tmp_filename, self.name)


### PR DESCRIPTION
According to the documentation on tempfile (ruby 1.9.1)
close 'unlinks' (deletes) the file and that might not be proper if we still want to rename it etc.

As for us, we've encountered problems with this as the file is deleted before the zip is done.

´´´
Stacktrace:
C:/ruby193/lib/ruby/1.9.1/tempfile.rb:346:in `rmdir'
C:/ruby193/lib/ruby/1.9.1/tempfile.rb:346:in`rmdir'
C:/ruby193/lib/ruby/1.9.1/tempfile.rb:338:in `ensure in locking'
C:/ruby193/lib/ruby/1.9.1/tempfile.rb:338:in`locking'
C:/ruby193/lib/ruby/1.9.1/tempfile.rb:144:in `block in initialize'
C:/ruby193/lib/ruby/1.9.1/tmpdir.rb:133:in`create'
C:/ruby193/lib/ruby/1.9.1/tempfile.rb:134:in `initialize'
C:/ruby193/lib/ruby/gems/1.9.1/gems/rubyzip-1.1.0/lib/zip/file.rb:416:in`new'
C:/ruby193/lib/ruby/gems/1.9.1/gems/rubyzip-1.1.0/lib/zip/file.rb:416:in `get_tempfile'
C:/ruby193/lib/ruby/gems/1.9.1/gems/rubyzip-1.1.0/lib/zip/file.rb:404:in`on_success_replace'
C:/ruby193/lib/ruby/gems/1.9.1/gems/rubyzip-1.1.0/lib/zip/file.rb:302:in `commit'
C:/ruby193/lib/ruby/gems/1.9.1/gems/rubyzip-1.1.0/lib/zip/file.rb:325:in`close'
C:/ruby193/lib/ruby/gems/1.9.1/gems/rubyzip-1.1.0/lib/zip/file.rb:101:in `open'

```

I'm not certain, but I think this fixes this issue. All tests are still green, and hopefully I can figure out a way to write one for this as well... 
```
