### PR TITLE
Default argument for OutputStream::write_buffer

### DIFF
--- a/lib/zip/output_stream.rb
+++ b/lib/zip/output_stream.rb
@@ -55,7 +55,7 @@ module Zip
       end
 
       # Same as #open but writes to a filestream instead
-      def write_buffer(io)
+      def write_buffer(io = ::StringIO.new(''))
         zos = new(io, true)
         yield zos
         zos.close_buffer


### PR DESCRIPTION
Adding the io parameter to OutputStream::write_buffer breaks backward compatibility with v1.1.0. Adding a default value reinstates backward compatibility.
