### PR TITLE
Alias for legacy error names

### DIFF
--- a/lib/zip/errors.rb
+++ b/lib/zip/errors.rb
@@ -5,4 +5,12 @@ module Zip
   class CompressionMethodError < Error; end
   class EntryNameError < Error; end
   class InternalError < Error; end
+
+  # Backwards compatibility with v1 (delete in v2)
+  ZipError = Error
+  ZipEntryExistsError = EntryExistsError
+  ZipDestinationFileExistsError = DestinationFileExistsError
+  ZipCompressionMethodError = CompressionMethodError
+  ZipEntryNameError = EntryNameError
+  ZipInternalError = InternalError
 end

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+require 'test_helper'
+
+class ErrorsTest < MiniTest::Unit::TestCase
+
+  def test_rescue_legacy_zip_error
+    raise ::Zip::Error
+  rescue ::Zip::ZipError
+  end
+
+  def test_rescue_legacy_zip_entry_exists_error
+    raise ::Zip::EntryExistsError
+  rescue ::Zip::ZipEntryExistsError
+  end
+
+  def test_rescue_legacy_zip_destination_file_exists_error
+    raise ::Zip::DestinationFileExistsError
+  rescue ::Zip::ZipDestinationFileExistsError
+  end
+
+  def test_rescue_legacy_zip_compression_method_error
+    raise ::Zip::CompressionMethodError
+  rescue ::Zip::ZipCompressionMethodError
+  end
+
+  def test_rescue_legacy_zip_entry_name_error
+    raise ::Zip::EntryNameError
+  rescue ::Zip::ZipEntryNameError
+  end
+
+  def test_rescue_legacy_zip_internal_error
+    raise ::Zip::InternalError
+  rescue ::Zip::ZipInternalError
+  end
+
+end


### PR DESCRIPTION
Ensure we maintain the v1 interface until v2 is released. This fixes issue #153.
