### PR TITLE
Don't send empty string to stream

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -273,7 +273,7 @@ module Zip
       io << pack_local_entry
 
       io << @name
-      io << (@extra ? @extra.to_local_bin : '')
+      io << @extra.to_local_bin if @extra
       @local_header_size = io.tell - @local_header_offset
     end
 


### PR DESCRIPTION
Unneeded method call removed. Don't call << if not needed
This was causing an issue in rails 4 and zipline. Which is now fixed https://github.com/fringd/zipline/pull/10 . However fixing this issue in rubyzip might prevent hard to track down bug for somebody else.
