### PR TITLE
Zip::Entry::DEFLATED is forced on every file

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -539,7 +539,7 @@ module Zip
       if @ftype == :directory
         zip_output_stream.put_next_entry(self, nil, nil, ::Zip::Entry::STORED)
       elsif @filepath
-        zip_output_stream.put_next_entry(self, nil, nil, ::Zip::Entry::DEFLATED)
+        zip_output_stream.put_next_entry(self, nil, nil, self.compression_method || ::Zip::Entry::DEFLATED)
         get_input_stream { |is| ::Zip::IOExtras.copy_stream(zip_output_stream, is) }
       else
         zip_output_stream.copy_raw_entry(self)

--- a/test/data/mimetype
+++ b/test/data/mimetype
@@ -1,0 +1,1 @@
+application/epub+zip


### PR DESCRIPTION
Hi,

I do not know if this is the right place to fix this but I found that I was unable to just store a file without compressing it.

So, if this is wrong I like to hear about it.

Thanks,
Mehmet
