### PR TITLE
Return created zip file from Zip::File.open when supplied a block

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -97,6 +97,7 @@ module Zip
         return zf unless block_given?
         begin
           yield zf
+          zf
         ensure
           zf.close
         end

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -38,6 +38,18 @@ class ZipFileTest < MiniTest::Unit::TestCase
     assert_equal(2, zfRead.entries.length)
   end
 
+  def test_open_with_block_returns_zip_file
+    srcFile = "test/data/file2.txt"
+    entryName = "newEntryName.rb"
+    assert(::File.exist?(srcFile))
+    created_file = ::Zip::File.open(EMPTY_FILENAME, ::Zip::File::CREATE) do |zf|
+      zf.add(entryName, srcFile)
+    end
+
+    zfRead = ::Zip::File.new(EMPTY_FILENAME)
+    assert_equal(created_file, zfRead)
+  end
+
   def test_get_output_stream
     entryCount = nil
     ::Zip::File.open(TEST_ZIP.zip_name) {


### PR DESCRIPTION
This change is to match ruby zip’s behavior to core’s IO.open when
supplied a block.
