### PR TITLE
treat empty file as non-exists

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -70,7 +70,7 @@ module Zip
       @comment = ''
       @create  = create
       case
-      when !buffer && ::File.exist?(file_name)
+      when !buffer && ::File.size?(file_name)
         @create = nil
         @exist_file_perms = ::File.stat(file_name).mode
         ::File.open(name, 'rb') do |f|


### PR DESCRIPTION
Hi, 

In my case I need to create a temporary file by [`Tempfile.new`](http://ruby-doc.org/stdlib-2.0.0/libdoc/tempfile/rdoc/Tempfile.html#method-c-new), which creates a file with zero-length (but it [exists](http://www.ruby-doc.org/core-2.1.1/File.html#method-c-exist-3F)), then archive my content into it. But the existing code yields an error `central_directory.rb:143:in 'get_e_o_c_d': Zip end of central directory signature not found (Zip::Error)`, treating the zero-length file as an invalid zip. So I think it would be reasonable to treat a zero-length file as a file **needs to be created as a new zip**.
