### PR TITLE
Fix Travis config so that ruby-head can actually fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
     jdk: oraclejdk7
   - rvm: jruby-19mode
     jdk: openjdk7
+  allow_failures:
+    - rvm: ruby-head
 before_install:
   - gem update --system
   - gem --version
@@ -19,5 +21,3 @@ before_script:
   - sudo apt-get install -qq zip unzip
   - echo `whereis zip`
   - echo `whereis unzip`
-allow_failures:
-  - rvm: ruby-head


### PR DESCRIPTION
The allow_failures set up needs to be in the matrix definition. If that's really what we want then this fixes that.
