### PR TITLE
Use the latest version of minitest.

### DIFF
--- a/rubyzip.gemspec
+++ b/rubyzip.gemspec
@@ -18,6 +18,6 @@ spec = Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'pry', '~> 0.10'
-  s.add_development_dependency 'minitest', '~> 5.2.0'
+  s.add_development_dependency 'minitest', '~> 5.4'
   s.add_development_dependency 'coveralls', '~> 0.7'
 end


### PR DESCRIPTION
Now the real culprit of the random test failures has been fixed [1] we can use
the latest version of minitest.

[1] https://github.com/amco/rubyzip/commit/96f84aee4c575a0c886462abb809ef47e2866f94
