### PR TITLE
markdown: recursive zipping example improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,16 @@ require 'pathname'
 
 directory = '/Users/me/Desktop/directory_to_zip' # last slash could be omitted
 zipfile_name = '/Users/me/Desktop/recursive_directory.zip'
+
+
+# available options:
+# "directories-skip" - skip directories
+# "directories-recursively" - archive directories recursively
+# "directories-recursively-splat" - archiving should splat directory
+# if so, directory splatting it's content into top-level
+
 options = {"directories-recursively"=>true}
+
 Zip::File.open(archive,Zip::File::CREATE) do |zipfile|
         files.each{
           |file_to_be_zipped|


### PR DESCRIPTION
Here it is
Last slash could be omitted in directory name, so, the best thing to do is Pathname module and relative_from_path method
