### PR TITLE
prevent tempfile path from being unlinked by garbage collection

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -403,6 +403,7 @@ module Zip
     def on_success_replace
       tmpfile      = get_tempfile
       tmp_filename = tmpfile.path
+      ObjectSpace.undefine_finalizer(tmpfile)
       tmpfile.close
       if yield tmp_filename
         ::File.rename(tmp_filename, self.name)
@@ -410,6 +411,8 @@ module Zip
           ::File.chmod(@exist_file_perms, self.name)
         end
       end
+    ensure
+      tmpfile.unlink if tmpfile
     end
 
     def get_tempfile


### PR DESCRIPTION
In one of our tests, we noticed that we were getting intermittent `Errno::ENOENT: No such file or directory` errors here when reaching `::File.rename(tmp_filename, self.name)`. 

After some investigation I found that the garbage collector happened to be running the finalizer for `tmpfile` during the entry writing block in `File#commit`, which tries to unlink the file (and succeeds if you're on a non-Windows environment).