### PR TITLE
Encode the filename read from zip file to UTF-8

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -1,3 +1,5 @@
+require 'nkf'
+
 module Zip
   class Entry
     STORED   = 0
@@ -234,7 +236,7 @@ module Zip
       end
       set_time(@last_mod_date, @last_mod_time)
 
-      @name = io.read(@name_length)
+      @name = to_utf8(io.read(@name_length))
       extra = io.read(@extra_length)
 
       @name.gsub!('\\', '/')
@@ -364,7 +366,7 @@ module Zip
       unpack_c_dir_entry(static_sized_fields_buf)
       check_c_dir_entry_signature
       set_time(@last_mod_date, @last_mod_time)
-      @name = io.read(@name_length).tr('\\', '/')
+      @name = to_utf8(io.read(@name_length)).tr('\\', '/')
       read_c_dir_extra_field(io)
       @comment = io.read(@comment_length)
       check_c_dir_entry_comment_size
@@ -682,6 +684,10 @@ module Zip
           @extra.delete('Zip64Placeholder')
         end
       end
+    end
+
+    def to_utf8(s)
+      ::NKF.nkf('-m0wx', s)
     end
 
   end


### PR DESCRIPTION
The file names in the zip file are not encoded by UTF-8 when it is created by MS Windows.