### PR TITLE
Be smarter about handling buffer file modes

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -121,11 +121,18 @@ module Zip
         if io.is_a?(::String)
           require 'stringio'
           io = ::StringIO.new(io)
+        elsif io.is_a?(IO)
+          # https://github.com/rubyzip/rubyzip/issues/119
+          io.binmode
         end
         zf = ::Zip::File.new(io, true, true, options)
         zf.read_from_stream(io)
         yield zf
-        zf.write_buffer(io)
+        begin
+          zf.write_buffer(io)
+        rescue IOError => e
+          raise unless e.message == "not opened for writing"
+        end
       end
 
       # Iterates over the contents of the ZipFile. This is more efficient

--- a/lib/zip/output_stream.rb
+++ b/lib/zip/output_stream.rb
@@ -29,7 +29,7 @@ module Zip
       @file_name = file_name
       @output_stream = if stream
                          iostream = @file_name.dup
-                         iostream.reopen
+                         iostream.reopen(@file_name)
                          iostream.rewind
                          iostream
                        else


### PR DESCRIPTION
This is a fix for #119.

The test suite still runs, but I have not added a test for this fix because I'm not sure if the behavior I defined is correct.

1. **Force binary mode** (`file.rb`): I noticed that the errors went away when I opened files in binary mode, like `rubyzip` itself does when you pass a filename to `Zip::File.open`, so now it forces binary mode when you pass an IO object.

1. **Abort unnecessary writes** (`output_stream.rb`): If you don't pass a stream which was opened for writing, then this results in a "not opened for writing" error, even if you didn't actually try to write anything.

The second part is probably not correct; I imagine the best fix would be one that only bothers doing `zf.write_buffer(io)` if changes were actually made to the in-memory archive.