### PR TITLE
Readme: Print data instead of puts

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ class ZipFileGenerator
         subdir =Dir.entries(diskFilePath); subdir.delete("."); subdir.delete("..")
         writeEntries(subdir, zipFilePath, io)
       else
-        io.get_output_stream(zipFilePath) { |f| f.puts(File.open(diskFilePath, "rb").read())}
+        io.get_output_stream(zipFilePath) { |f| f.print(File.open(diskFilePath, "rb").read())}
       end
     }
   end


### PR DESCRIPTION
Zipping a directory with the old example would change the content of a file by adding a newline to the data getting zipped.
This is bad if you want to validate files of zip with checksums or, in my case, it corrupts git index files if you zip a git-directory.