### PR TITLE
Case-insensitive version of Zip::EntrySet#find_entry

### DIFF
--- a/lib/zip/entry_set.rb
+++ b/lib/zip/entry_set.rb
@@ -17,6 +17,11 @@ module Zip
       @entry_set[to_key(entry)]
     end
 
+    def find_entry_case_insensitive(entry)
+      entry = @entry_set.find { |k, _| k.downcase == to_key(entry).downcase }
+      entry.last if entry
+    end
+
     def <<(entry)
       @entry_set[to_key(entry)] = entry
     end


### PR DESCRIPTION
Please consider including a method to find entries case-insensitively. Such a need arose, in particular, from [this issue](https://github.com/weshatheleopard/rubyXL/issues/175). In short, some .xlsx files (that are actually zip archives) may come malformed in a way that the contained file names differ in case from the standard.

The patch will fail on non-ascii strings unless Ruby 2.3.0 is released (where proper UTF8 case conversion is [promised](https://bugs.ruby-lang.org/issues/10085)), but so far no one complained..