### PR TITLE
Case insensitivity option for #find_entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ Gemfile.lock
 +samples/*.zip.*
 coverage
 pkg/
+.ruby-gemset
+.ruby-version

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -221,7 +221,7 @@ module Zip
     def read_local_entry(io) #:nodoc:all
       @local_header_offset = io.tell
 
-      static_sized_fields_buf = io.read(::Zip::LOCAL_ENTRY_STATIC_HEADER_LENGTH)
+      static_sized_fields_buf = io.read(::Zip::LOCAL_ENTRY_STATIC_HEADER_LENGTH) || ''
 
       unless static_sized_fields_buf.bytesize == ::Zip::LOCAL_ENTRY_STATIC_HEADER_LENGTH
         raise Error, "Premature end of file. Not enough data for zip entry local header"

--- a/lib/zip/entry_set.rb
+++ b/lib/zip/entry_set.rb
@@ -13,8 +13,10 @@ module Zip
       @entry_set.include?(to_key(entry))
     end
 
-    def find_entry(entry)
-      @entry_set[to_key(entry)]
+    def find_entry(entry, case_sensitively = true)
+      return @entry_set[to_key(entry)] if case_sensitively
+      entry = @entry_set.find { |k, _| k.downcase == to_key(entry).downcase }
+      entry.last if entry
     end
 
     def <<(entry)

--- a/test/entry_set_test.rb
+++ b/test/entry_set_test.rb
@@ -65,6 +65,12 @@ class ZipEntrySetTest < MiniTest::Test
     assert_equal(ZIP_ENTRIES, @zipEntrySet.entries)
   end
 
+  def test_find_entry
+    # by default, #find_entry is case-sensitive
+    assert_equal(ZIP_ENTRIES[0], @zipEntrySet.find_entry('name1'))
+    assert_equal(ZIP_ENTRIES[0], @zipEntrySet.find_entry('NaMe1', false))
+  end
+
   def test_entries_with_sort
     ::Zip.sort_entries = true
     assert_equal(ZIP_ENTRIES.sort, @zipEntrySet.entries)


### PR DESCRIPTION
So here's another take on https://github.com/rubyzip/rubyzip/pull/217
In the end I decided that once case-insensitivity is being implemented in this single method, adding an extra configuration option would not be justified, as that option would not turn `rubyzip` case-insensitive throughout.
Pull if you consider this solution acceptable.