### PR TITLE
Less sloppy implementation of case insensitive matching

### DIFF
--- a/lib/zip.rb
+++ b/lib/zip.rb
@@ -37,7 +37,7 @@ end
 
 module Zip
   extend self
-  attr_accessor :unicode_names, :on_exists_proc, :continue_on_exists_proc, :sort_entries, :default_compression, :write_zip64_support, :warn_invalid_date
+  attr_accessor :unicode_names, :on_exists_proc, :continue_on_exists_proc, :sort_entries, :default_compression, :write_zip64_support, :warn_invalid_date, :case_insensitive_match
 
   def reset!
     @_ran_once = false
@@ -48,6 +48,7 @@ module Zip
     @default_compression = ::Zlib::DEFAULT_COMPRESSION
     @write_zip64_support = false
     @warn_invalid_date = true
+    @case_insensitive_match = false
   end
 
   def setup

--- a/lib/zip/entry_set.rb
+++ b/lib/zip/entry_set.rb
@@ -78,7 +78,9 @@ module Zip
 
     private
     def to_key(entry)
-      entry.to_s.chomp('/')
+      k = entry.to_s.chomp('/')
+      k.downcase! if ::Zip.case_insensitive_match
+      k
     end
   end
 end

--- a/lib/zip/entry_set.rb
+++ b/lib/zip/entry_set.rb
@@ -13,7 +13,7 @@ module Zip
       @entry_set.include?(to_key(entry))
     end
 
-    def find_entry(entry, case_sensitively = true)
+    def find_entry(entry)
       @entry_set[to_key(entry)]
     end
 

--- a/lib/zip/entry_set.rb
+++ b/lib/zip/entry_set.rb
@@ -14,9 +14,7 @@ module Zip
     end
 
     def find_entry(entry, case_sensitively = true)
-      return @entry_set[to_key(entry)] if case_sensitively
-      entry = @entry_set.find { |k, _| k.downcase == to_key(entry).downcase }
-      entry.last if entry
+      @entry_set[to_key(entry)]
     end
 
     def <<(entry)

--- a/test/case_sensitivity_test.rb
+++ b/test/case_sensitivity_test.rb
@@ -1,0 +1,70 @@
+require 'test_helper'
+
+
+class ZipFileTest < MiniTest::Test
+  include CommonZipFileFixture
+
+  SRC_FILES = [ [ "test/data/file1.txt", "testfile.rb" ], 
+                [ "test/data/file2.txt", "testFILE.rb" ] ]
+
+  def teardown
+    ::Zip.case_insensitive_match = false
+  end
+
+  # Ensure that everything functions normally when +case_insensitive_match = false+
+  def test_add_case_sensitive
+    ::Zip.case_insensitive_match = false
+
+    SRC_FILES.each { |fn, en| assert(::File.exist?(fn)) }
+    zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
+
+    SRC_FILES.each { |fn, en| zf.add(en, fn) }
+    zf.close
+
+    zfRead = ::Zip::File.new(EMPTY_FILENAME)
+    assert_equal(SRC_FILES.size, zfRead.entries.length)
+    SRC_FILES.each_with_index { |a, i|
+      assert_equal(a.last, zfRead.entries[i].name)
+      AssertEntry.assert_contents(a.first,
+                                  zfRead.get_input_stream(a.last) { |zis| zis.read })
+    }
+  end
+
+  # Ensure that names are treated case insensitively when adding files and +case_insensitive_match = false+
+  def test_add_case_insensitive
+    ::Zip.case_insensitive_match = true
+
+    SRC_FILES.each { |fn, en| assert(::File.exist?(fn)) }
+    zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
+
+    assert_raises Zip::EntryExistsError do
+        SRC_FILES.each { |fn, en| zf.add(en, fn) }
+    end
+
+  end
+
+  # Ensure that names are treated case insensitively when reading files and +case_insensitive_match = true+
+  def test_add_case_sensitive_read_case_insensitive
+    ::Zip.case_insensitive_match = false
+
+    SRC_FILES.each { |fn, en| assert(::File.exist?(fn)) }
+    zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
+
+    SRC_FILES.each { |fn, en| zf.add(en, fn) }
+    zf.close
+
+    ::Zip.case_insensitive_match = true
+
+    zfRead = ::Zip::File.new(EMPTY_FILENAME)
+    assert_equal(SRC_FILES.collect{ |fn, en| en.downcase}.uniq.size, zfRead.entries.length)
+    assert_equal(SRC_FILES.last.last.downcase, zfRead.entries.first.name.downcase)
+    AssertEntry.assert_contents(SRC_FILES.last.first,
+                                zfRead.get_input_stream(SRC_FILES.last.last) { |zis| zis.read })
+  end
+
+  private
+  def assert_contains(zf, entryName, filename = entryName)
+    assert(zf.entries.detect { |e| e.name == entryName } != nil, "entry #{entryName} not in #{zf.entries.join(', ')} in zip file #{zf}")
+    assert_entryContents(zf, entryName, filename) if File.exist?(filename)
+  end
+end

--- a/test/entry_set_test.rb
+++ b/test/entry_set_test.rb
@@ -66,9 +66,17 @@ class ZipEntrySetTest < MiniTest::Test
   end
 
   def test_find_entry
-    # by default, #find_entry is case-sensitive
-    assert_equal(ZIP_ENTRIES[0], @zipEntrySet.find_entry('name1'))
-    assert_equal(ZIP_ENTRIES[0], @zipEntrySet.find_entry('NaMe1', false))
+    entries = [::Zip::Entry.new("zipfile.zip", "MiXeDcAsEnAmE", "comment1")]
+
+    ::Zip.case_insensitive_match = true
+    zipEntrySet = ::Zip::EntrySet.new(entries)
+    assert_equal(entries[0], zipEntrySet.find_entry('MiXeDcAsEnAmE'))
+    assert_equal(entries[0], zipEntrySet.find_entry('mixedcasename'))
+
+    ::Zip.case_insensitive_match = false
+    zipEntrySet = ::Zip::EntrySet.new(entries)
+    assert_equal(entries[0], zipEntrySet.find_entry('MiXeDcAsEnAmE'))
+    assert_equal(nil, zipEntrySet.find_entry('mixedcasename'))
   end
 
   def test_entries_with_sort


### PR DESCRIPTION
Case insensitivity is required by certain other software packages (most notably, MS EXCEL, may God punish its developers) that do not pay attention to filename capitalization.

@rastarobot attempted to mitigate that in Issue #222, but did it rather sloppily, so let's do it right this time.

Now `::Zip` has a `case_insensitive_match` parameter, which, if set to `true`, makes `File.TXT` and `file.txt` equivalent for all intents and purposes. 