### PR TITLE
Do something more expected with new file permissions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,16 @@ fruit/orange
 
 After this, entries in the zip archive will be saved in ordered state.
 
+### Default permissions of zip archives
+
+On Posix file systems the default file permissions applied to a new archive
+are (0666 - umask), which mimics the behavior of standard tools such as `touch`.
+
+On Windows the default file permissions are set to 0644 as suggested by the
+[Ruby File documentation](http://ruby-doc.org/core-2.2.2/File.html).
+
+When modifying a zip archive the file permissions of the archive are preserved.
+
 ### Reading a Zip file
 
 ```ruby

--- a/test/file_permissions_test.rb
+++ b/test/file_permissions_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class FilePermissionsTest < MiniTest::Test
+
+  FILENAME = File.join(File.dirname(__FILE__), "umask.zip")
+
+  def teardown
+    ::File.unlink(FILENAME)
+  end
+
+  if ::Zip::RUNNING_ON_WINDOWS
+    # Windows tests
+
+    DEFAULT_PERMS = 0644
+
+    def test_windows_perms
+      create_file
+
+      assert_equal DEFAULT_PERMS, ::File.stat(FILENAME).mode
+    end
+
+  else
+    # Unix tests
+
+    DEFAULT_PERMS = 0100666
+
+    def test_current_umask
+      umask = DEFAULT_PERMS - ::File.umask
+      create_file
+
+      assert_equal umask, ::File.stat(FILENAME).mode
+    end
+
+    def test_umask_000
+      set_umask(0000) do
+        create_file
+      end
+
+      assert_equal DEFAULT_PERMS, ::File.stat(FILENAME).mode
+    end
+
+    def test_umask_066
+      umask = 0066
+      set_umask(umask) do
+        create_file
+      end
+
+      assert_equal((DEFAULT_PERMS - umask), ::File.stat(FILENAME).mode)
+    end
+
+  end
+
+  def create_file
+    ::Zip::File.open(FILENAME, ::Zip::File::CREATE) do |zip|
+      zip.comment = "test"
+    end
+  end
+
+  # If anything goes wrong, make sure the umask is restored.
+  def set_umask(umask, &block)
+    begin
+      saved_umask = ::File.umask(umask)
+      yield
+    ensure
+      ::File.umask(saved_umask)
+    end
+  end
+
+end


### PR DESCRIPTION
This fixes #204.

Instead of inheriting the permissions from the tmp directory, new files should
have permissions that reflect the defaults on the system taking umask into
account.

It seems that (unix) permissions of 666 - umask are as close to a standard as
anything [1] and that 'touch' uses this. On Windows it seems sensible to just
use 644 directly [2].

[1] http://unix.stackexchange.com/a/102080
[2] http://ruby-doc.org/core-1.9.3/File.html