### PR TITLE
Accept StringIO in Zip.open_buffer

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -115,8 +115,8 @@ module Zip
       # (This can be used to extract data from a
       # downloaded zip archive without first saving it to disk.)
       def open_buffer(io, options = {})
-        unless io.is_a?(IO) || io.is_a?(String) || io.is_a?(Tempfile)
-          raise "Zip::File.open_buffer expects an argument of class String, IO, or Tempfile. Found: #{io.class}"
+        unless io.is_a?(IO) || io.is_a?(String) || io.is_a?(Tempfile) || io.is_a?(StringIO)
+          raise "Zip::File.open_buffer expects an argument of class String, IO, StringIO, or Tempfile. Found: #{io.class}"
         end
         if io.is_a?(::String)
           require 'stringio'

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -82,6 +82,13 @@ class ZipFileTest < MiniTest::Test
     end
   end
 
+  def test_open_buffer_with_stringio
+    string_io = StringIO.new File.read('test/data/rubycode.zip')
+    ::Zip::File.open_buffer string_io do |zf|
+      assert zf.entries.map { |e| e.name }.include?('zippedruby1.rb')
+    end
+  end
+
   def test_cleans_up_tempfiles_after_close
     zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
     zf.get_output_stream('myFile') do |os|


### PR DESCRIPTION
It'd be really handy if `open_buffer` accepted a StringIO parameter, because I could just give it the `body` attribute of a Rails request, which can either be an IO or a StringIO.

The `open_buffer` implementation wraps String buffers into StringIO instances, so it appears that it should be able to use a StringIO without any deep changes. I updated the checks and added a test verifying the new code.

Will you please consider merging this?

Thank you very much for rubyzip! 