### PR TITLE
Use duck typing with IO methods.

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -176,7 +176,7 @@ module Zip
       end
 
       def read_c_dir_entry(io) #:nodoc:all
-        path = if io.is_a?(::IO)
+        path = if io.respond_to?(:path)
                  io.path
                else
                  io
@@ -548,7 +548,7 @@ module Zip
     end
 
     def get_raw_input_stream(&block)
-      if @zipfile.is_a?(::IO) || @zipfile.is_a?(::StringIO)
+      if @zipfile.respond_to?(:seek) && @zipfile.respond_to?(:read)
         yield @zipfile
       else
         ::File.open(@zipfile, 'rb', &block)

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -49,6 +49,7 @@ module Zip
     MAX_SEGMENT_SIZE     = 3_221_225_472
     MIN_SEGMENT_SIZE     = 65_536
     DATA_BUFFER_SIZE     = 8192
+    IO_METHODS           = [:tell, :seek, :read, :close]
 
     attr_reader :name
 
@@ -117,13 +118,13 @@ module Zip
       # (This can be used to extract data from a
       # downloaded zip archive without first saving it to disk.)
       def open_buffer(io, options = {})
-        unless io.is_a?(IO) || io.is_a?(String) || io.is_a?(Tempfile) || io.is_a?(StringIO)
-          raise "Zip::File.open_buffer expects an argument of class String, IO, StringIO, or Tempfile. Found: #{io.class}"
+        unless IO_METHODS.map { |method| io.respond_to?(method) }.all? || io.is_a?(String)
+          raise "Zip::File.open_buffer expects a String or IO-like argument (responds to #{IO_METHODS.join(', ')}). Found: #{io.class}"
         end
         if io.is_a?(::String)
           require 'stringio'
           io = ::StringIO.new(io)
-        elsif io.is_a?(IO)
+        elsif io.respond_to?(:binmode)
           # https://github.com/rubyzip/rubyzip/issues/119
           io.binmode
         end

--- a/lib/zip/input_stream.rb
+++ b/lib/zip/input_stream.rb
@@ -111,8 +111,7 @@ module Zip
     protected
 
     def get_io(io_or_file, offset = 0)
-      case io_or_file
-      when IO, StringIO
+      if io_or_file.respond_to?(:seek)
         io = io_or_file.dup
         io.seek(offset, ::IO::SEEK_SET)
         io

--- a/test/case_sensitivity_test.rb
+++ b/test/case_sensitivity_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ZipFileTest < MiniTest::Test
+class ZipCaseSensitivityTest < MiniTest::Test
   include CommonZipFileFixture
 
   SRC_FILES = [['test/data/file1.txt', 'testfile.rb'],


### PR DESCRIPTION
Hey gang. This was necessary so I could stream a zipfile from S3 using the s3io gem. It seems a little bonkers to keep hard-coding the names of IO-like classes into rubyzip, doesn't it?

Additionally I had to splice in `seek` and `tell` methods to s3io using the more Rubyish ``@pos``, which it supports instead. Maybe rubyzip could be made to use those methods as well, for increased compatibility?