### PR TITLE
Don't enable JRuby objectspace

### DIFF
--- a/lib/zip.rb
+++ b/lib/zip.rb
@@ -30,10 +30,6 @@ require 'zip/streamable_stream'
 require 'zip/streamable_directory'
 require 'zip/constants'
 require 'zip/errors'
-if defined? JRUBY_VERSION
-  require 'jruby'
-  JRuby.objectspace = true
-end
 
 module Zip
   extend self

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -405,14 +405,11 @@ module Zip
     def on_success_replace
       tmpfile      = get_tempfile
       tmp_filename = tmpfile.path
-      ObjectSpace.undefine_finalizer(tmpfile)
       tmpfile.close
       if yield tmp_filename
         ::File.rename(tmp_filename, name)
         ::File.chmod(@file_permissions, name) if defined?(@file_permissions)
       end
-    ensure
-      tmpfile.unlink if tmpfile
     end
 
     def get_tempfile

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -405,11 +405,11 @@ module Zip
     def on_success_replace
       tmpfile      = get_tempfile
       tmp_filename = tmpfile.path
-      tmpfile.close
       if yield tmp_filename
         ::File.rename(tmp_filename, name)
         ::File.chmod(@file_permissions, name) if defined?(@file_permissions)
       end
+      tmpfile.close
     end
 
     def get_tempfile

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -406,7 +406,9 @@ module Zip
       tmpfile      = get_tempfile
       tmp_filename = tmpfile.path
       if yield tmp_filename
-        ::File.rename(tmp_filename, name)
+        new_file = ::File.new(name, "w")
+        IO.copy_stream tmpfile, new_file
+        new_file.close
         ::File.chmod(@file_permissions, name) if defined?(@file_permissions)
       end
       tmpfile.close

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,11 @@ require 'digest/sha1'
 require 'zip'
 require 'gentestfiles'
 
+if defined? JRUBY_VERSION
+  require 'jruby'
+  JRuby.objectspace = true
+end
+
 TestFiles.create_test_files
 TestZipFile.create_test_zips
 


### PR DESCRIPTION
From the JRuby wiki:

> ObjectSpace has been disabled by default since version 1.1b1. Some users reenable ObjectSpace, using the -X+O flag (previously +O), without realizing what a massive performance hit this is. If you are running with ObjectSpace enabled, do not expect any sort of performance.

https://github.com/jruby/jruby/wiki/PerformanceTuning#dont-enable-objectspace

This was enabled in 04029115. @simonoff, do you remember the rationale? I found no discussion in any issues or PRs: https://github.com/rubyzip/rubyzip/issues?utf8=%E2%9C%93&q=objectspace

Some basic tests in my app show that nothing breaks without this enabled.