### PR TITLE
Restore 1.9.3 and add 1.9.2 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
+  - 1.9.2
+  - 1.9.3
   - 2.0.0
   - 2.1.5
   - 2.2.0


### PR DESCRIPTION
1.9.3 was removed from .travis.yml in 0cbae14c76d698840f4c60e62bda6ce0f30e6f37 but without an explanation for doing so.

Rubyzip is described as requiring 1.9.2 or greater, without any versions being described as unsupported, so 1.9.2 and 1.9.3 should be included in the versions tested.

The main reason I'm adding them to the testing matrix is that I'm investigating a problem with rb-roo/roo and Ruby 1.9.3, and I want to check whether roo or rubyzip is the problem.