### PR TITLE
Restore setting Tempfile to binmode

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -415,7 +415,7 @@ module Zip
     end
 
     def get_tempfile
-      Tempfile.new(::File.basename(name), ::File.dirname(name))
+      Tempfile.new(::File.basename(name), ::File.dirname(name), binmode: true)
     end
 
     def create_file_permissions


### PR DESCRIPTION
This partially reverts 8447f0e2302989615eb0141f31911fe36130f292 ([line 418](https://github.com/rubyzip/rubyzip/commit/8447f0e2302989615eb0141f31911fe36130f292#diff-b2465821a9969effeacd35f1d69e18e6R418)) which was a fix for an unrelated issue (#252) that silently removed an explicit call to set the `Tempfile` to binmode.  ZIP files are binary and we never want Ruby to do any conversions because it could corrupt the file.  By default, a Tempfile is not opened in binmode.

    irb> RUBY_VERSION
    => "2.2.3"
    irb> require 'tempfile'
    => true
    irb> Tempfile.new("foo").binmode?
    => false
    irb> Tempfile.new("foo", binmode: true).binmode?
    => true
