### PR TITLE
Fix accidental unlink (#185) without using ObjectSpace (#252)

### DIFF
--- a/lib/zip.rb
+++ b/lib/zip.rb
@@ -1,6 +1,7 @@
 require 'delegate'
 require 'singleton'
 require 'tempfile'
+require 'tmpdir'
 require 'fileutils'
 require 'stringio'
 require 'zlib'


### PR DESCRIPTION

 - #185 reported that a file was unexpectedly deleted by the `Tempfile` finalizer and added `ObjectSpace.undefine_finalizer` to work around that.
 - #252 reported that `ObjectSpace` introduced in #185 should be avoided for JRuby.
 - 8447f0e2302989615eb0141f31911fe36130f292 removed `ObjectSpace` but reintroduced the problem of #185.

This patch fixes both #185 and #252.  It removes use of `Tempfile` so we don't fight its finalizer and don't need to use `ObjectSpace`.  It uses `Dir::Tmpname` and `File` to make the named temporary file instead.  There is no chance of accidental unlink and the code becomes more clear.