### PR TITLE
Add correct test for `Zip.warn_invalid_date` attribute

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -564,7 +564,7 @@ module Zip
     def set_time(binary_dos_date, binary_dos_time)
       @time = ::Zip::DOSTime.parse_binary_dos_format(binary_dos_date, binary_dos_time)
     rescue ArgumentError
-      STDERR.puts 'Invalid date/time in zip entry' if ::Zip.warn_invalid_date
+      warn 'Invalid date/time in zip entry' if ::Zip.warn_invalid_date
     end
 
     def create_file(dest_path, _continue_on_exists_proc = proc { Zip.continue_on_exists_proc })

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -70,7 +70,9 @@ class ZipSettingsTest < MiniTest::Test
     test_file = File.join(File.dirname(__FILE__), 'data', 'WarnInvalidDate.zip')
     Zip.warn_invalid_date = false
 
-    ::Zip::File.open(test_file) do |_zf|
+    assert_output('', '') do
+      ::Zip::File.open(test_file) do |_zf|
+      end
     end
   end
 
@@ -78,7 +80,9 @@ class ZipSettingsTest < MiniTest::Test
     test_file = File.join(File.dirname(__FILE__), 'data', 'WarnInvalidDate.zip')
     Zip.warn_invalid_date = true
 
-    ::Zip::File.open(test_file) do |_zf|
+    assert_output('', /Invalid date\/time in zip entry/) do
+      ::Zip::File.open(test_file) do |_zf|
+      end
     end
   end
 


### PR DESCRIPTION
While I added this attibute in https://github.com/rubyzip/rubyzip/pull/195 I have no idea how to check `STDERR` output.
Now I found out, that there is `assert_output` method in `minitest`, so test will check it.