### PR TITLE
Fix in example_recursive

### DIFF
--- a/samples/example_recursive.rb
+++ b/samples/example_recursive.rb
@@ -51,7 +51,7 @@ class ZipFileGenerator
 
   def put_into_archive(disk_file_path, io, zip_file_path)
     io.get_output_stream(zip_file_path) do |f|
-      f.puts(File.open(disk_file_path, 'rb').read)
+      f.write(File.open(disk_file_path, 'rb').read)
     end
   end
 end


### PR DESCRIPTION
Replacing 'puts' with 'write' as 'puts' was adding extra lines in files,
damaging them. Ref : https://github.com/rubyzip/rubyzip/issues/260