### PR TITLE
Add length method to InputStream

### DIFF
--- a/lib/zip/input_stream.rb
+++ b/lib/zip/input_stream.rb
@@ -108,6 +108,11 @@ module Zip
       end
     end
 
+    def entry_size
+      return 0 if @current_entry.nil?
+      @current_entry.size
+    end
+
     protected
 
     def get_io(io_or_file, offset = 0)

--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -105,6 +105,10 @@ module Zip
       rescue EOFError
       end
 
+      def length
+        entry_size
+      end
+
       alias_method :each, :each_line
     end
   end

--- a/test/input_stream_test.rb
+++ b/test/input_stream_test.rb
@@ -179,4 +179,16 @@ class ZipInputStreamTest < MiniTest::Test
       assert_equal('$VERBOSE =', zis.read(10))
     end
   end
+
+  def test_test_entry_size
+    ::Zip::InputStream.open(TestZipFile::TEST_ZIP2.zip_name) do |zis|
+      assert_equal(zis.entry_size, 0)
+      zis.get_next_entry
+      assert_equal(zis.entry_size, 123702)
+      zis.get_next_entry
+      zis.get_next_entry
+      zis.get_next_entry
+      assert_equal(zis.entry_size, 6)
+    end
+  end
 end

--- a/test/ioextras/abstract_input_stream_test.rb
+++ b/test/ioextras/abstract_input_stream_test.rb
@@ -30,6 +30,10 @@ class AbstractInputStreamTest < MiniTest::Test
     def input_finished?
       @contents[@readPointer].nil?
     end
+
+    def entry_size
+      @contents.length
+    end
   end
 
   def setup
@@ -98,5 +102,9 @@ class AbstractInputStreamTest < MiniTest::Test
       fail 'EOFError expected'
     rescue EOFError
     end
+  end
+
+  def test_length
+    assert_equal(TEST_STRING.length, @io.length)
   end
 end


### PR DESCRIPTION
To make this thing act more realistically like an IO, it needs a length method.

One useful example is being able to iterate through a zip of images and upload them to an HTTP server using `UploadIO`. In order to multi-part such a POST body, the length of the IO must be known.

Fixes #276 
