### PR TITLE
Replace puts with write in README.md for dir recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ class ZipFileGenerator
 
   def put_into_archive(disk_file_path, io, zip_file_path)
     io.get_output_stream(zip_file_path) do |f|
-      f.puts(File.open(disk_file_path, 'rb').read)
+      f.write(File.open(disk_file_path, 'rb').read)
     end
   end
 end


### PR DESCRIPTION
The instructions for zipping a directory recursively uses `puts`:

```
  def put_into_archive(disk_file_path, io, zip_file_path)
    io.get_output_stream(zip_file_path) do |f|
      f.puts(File.open(disk_file_path, 'rb').read)
    end
  end
```

This appends a newline character `0x0A` at the end of each file, which has just caused me a number of headaches :) 
