### PR TITLE
example_recursive.rb lost some special characters (0x1a at file end) …

### DIFF
--- a/samples/example_recursive.rb
+++ b/samples/example_recursive.rb
@@ -50,8 +50,6 @@ class ZipFileGenerator
   end
 
   def put_into_archive(disk_file_path, io, zip_file_path)
-    io.get_output_stream(zip_file_path) do |f|
-      f.write(File.open(disk_file_path, 'rb').read)
-    end
+    io.add(zip_file_path, disk_file_path)
   end
 end


### PR DESCRIPTION
…in file

example_recursive.rb lost some special characters ( for example 0x1a at file end ) , it should related to io stream implementation . Use internal zip add method instead of File.read could avoid this lose . 

An issue is posted at https://github.com/rubyzip/rubyzip/issues/296
