### PR TITLE
Clean up empty.zip after running tests.

### DIFF
--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -528,9 +528,8 @@ class ZipFileTest < MiniTest::Test
   end
 
   def test_empty_zip
-    puts `touch empty.zip`
     assert_raises(::Zip::Error) do
-      ::Zip::File.open('empty.zip')
+      ::Zip::File.open(TestFiles::NULL_FILE)
     end
   end
 

--- a/test/gentestfiles.rb
+++ b/test/gentestfiles.rb
@@ -9,6 +9,8 @@ class TestFiles
   RANDOM_BINARY_FILE1 = 'test/data/generated/randomBinary1.bin'
   RANDOM_BINARY_FILE2 = 'test/data/generated/randomBinary2.bin'
 
+  NULL_FILE = 'test/data/generated/null.zip' # Zero length, so not a zip file.
+
   EMPTY_TEST_DIR = 'test/data/generated/emptytestdir'
 
   ASCII_TEST_FILES = [RANDOM_ASCII_FILE1, RANDOM_ASCII_FILE2, RANDOM_ASCII_FILE3]
@@ -27,6 +29,8 @@ class TestFiles
       BINARY_TEST_FILES.each_with_index do |filename, index|
         create_random_binary(filename, 1E4 * (index + 1))
       end
+
+      system("touch #{NULL_FILE}")
 
       ensure_dir(EMPTY_TEST_DIR)
     end


### PR DESCRIPTION
After running the tests there was a file left in the project directory,
'empty.zip', which was simply 'touch'ed to use as a null file. Switch to create
this as one of the generated test files so it's cleaned up automatically.

Also, use 'null.zip' as the name as there is already an 'empty.zip' generated
that is a zip file, but empty.
