### PR TITLE
Fix permissions on new zip files (#294)

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -77,7 +77,6 @@ module Zip
           read_from_stream(f)
         end
       when create
-        @file_permissions = create_file_permissions
         @entry_set = EntrySet.new
       when ::File.zero?(file_name)
         raise Error, "File #{file_name} has zero size. Did you mean to pass the create flag?"
@@ -406,7 +405,7 @@ module Zip
       tmp_filename = create_tmpname
       if yield tmp_filename
         ::File.rename(tmp_filename, name)
-        ::File.chmod(@file_permissions, name) if defined?(@file_permissions)
+        ::File.chmod(@file_permissions, name) if @create.nil?
       end
     ensure
       ::File.unlink(tmp_filename) if ::File.exist?(tmp_filename)
@@ -415,14 +414,10 @@ module Zip
     def create_tmpname
       dirname, basename = ::File.split(name)
       ::Dir::Tmpname.create(basename, dirname) do |tmpname|
-        opts = {perm: 0600, mode: ::File::CREAT | ::File::WRONLY | ::File::EXCL}
+        opts = {mode: ::File::CREAT | ::File::WRONLY | ::File::EXCL}
         f = File.open(tmpname, opts)
         f.close
       end
-    end
-
-    def create_file_permissions
-      ::Zip::RUNNING_ON_WINDOWS ? 0644 : 0666 - ::File.umask
     end
   end
 end

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -402,23 +402,19 @@ module Zip
     end
 
     def on_success_replace
-      tmp_filename = create_tmpname
-      if yield tmp_filename
-        ::File.rename(tmp_filename, name)
-        ::File.chmod(@file_permissions, name) if @create.nil?
+      dirname, basename = ::File.split(name)
+      ::Dir::Tmpname.create(basename, dirname) do |tmp_filename|
+        begin
+          if yield tmp_filename
+            ::File.rename(tmp_filename, name)
+            ::File.chmod(@file_permissions, name) if @create.nil?
+          end
+        ensure
+          ::File.unlink(tmp_filename) if ::File.exist?(tmp_filename)
+        end
       end
-    ensure
-      ::File.unlink(tmp_filename) if ::File.exist?(tmp_filename)
     end
 
-    def create_tmpname
-      dirname, basename = ::File.split(name)
-      ::Dir::Tmpname.create(basename, dirname) do |tmpname|
-        opts = {mode: ::File::CREAT | ::File::WRONLY | ::File::EXCL}
-        f = File.open(tmpname, opts)
-        f.close
-      end
-    end
   end
 end
 

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -414,7 +414,6 @@ module Zip
         end
       end
     end
-
   end
 end
 

--- a/test/file_permissions_test.rb
+++ b/test/file_permissions_test.rb
@@ -43,9 +43,13 @@ class FilePermissionsTest < MiniTest::Test
 
       assert_equal ::File.stat(FILENAME).mode, ::File.stat(ZIPNAME).mode
     end
+
+    def test_umask_027
+      set_umask(0027) do
+        create_files
       end
 
-      assert_equal((DEFAULT_PERMS - umask), ::File.stat(FILENAME).mode)
+      assert_equal ::File.stat(FILENAME).mode, ::File.stat(ZIPNAME).mode
     end
 
   end

--- a/test/file_permissions_test.rb
+++ b/test/file_permissions_test.rb
@@ -2,9 +2,11 @@ require 'test_helper'
 
 class FilePermissionsTest < MiniTest::Test
 
-  FILENAME = File.join(File.dirname(__FILE__), "umask.zip")
+  ZIPNAME = File.join(File.dirname(__FILE__), "umask.zip")
+  FILENAME = File.join(File.dirname(__FILE__), "umask.txt")
 
   def teardown
+    ::File.unlink(ZIPNAME)
     ::File.unlink(FILENAME)
   end
 
@@ -14,35 +16,33 @@ class FilePermissionsTest < MiniTest::Test
     DEFAULT_PERMS = 0644
 
     def test_windows_perms
-      create_file
-
-      assert_equal DEFAULT_PERMS, ::File.stat(FILENAME).mode
+      create_files
+      assert_equal ::File.stat(FILENAME).mode, ::File.stat(ZIPNAME).mode
     end
 
   else
     # Unix tests
 
-    DEFAULT_PERMS = 0100666
-
     def test_current_umask
-      umask = DEFAULT_PERMS - ::File.umask
-      create_file
-
-      assert_equal umask, ::File.stat(FILENAME).mode
+      create_files
+      assert_equal ::File.stat(FILENAME).mode, ::File.stat(ZIPNAME).mode
     end
 
     def test_umask_000
       set_umask(0000) do
-        create_file
+        create_files
       end
 
-      assert_equal DEFAULT_PERMS, ::File.stat(FILENAME).mode
+      assert_equal ::File.stat(FILENAME).mode, ::File.stat(ZIPNAME).mode
     end
 
     def test_umask_066
-      umask = 0066
-      set_umask(umask) do
-        create_file
+      set_umask(0066) do
+        create_files
+      end
+
+      assert_equal ::File.stat(FILENAME).mode, ::File.stat(ZIPNAME).mode
+    end
       end
 
       assert_equal((DEFAULT_PERMS - umask), ::File.stat(FILENAME).mode)
@@ -50,9 +50,13 @@ class FilePermissionsTest < MiniTest::Test
 
   end
 
-  def create_file
-    ::Zip::File.open(FILENAME, ::Zip::File::CREATE) do |zip|
+  def create_files
+    ::Zip::File.open(ZIPNAME, ::Zip::File::CREATE) do |zip|
       zip.comment = "test"
+    end
+
+    ::File.open(FILENAME, 'w') do |file|
+      file << 'test'
     end
   end
 

--- a/test/file_permissions_test.rb
+++ b/test/file_permissions_test.rb
@@ -17,7 +17,7 @@ class FilePermissionsTest < MiniTest::Test
 
     def test_windows_perms
       create_files
-      assert_equal ::File.stat(FILENAME).mode, ::File.stat(ZIPNAME).mode
+      assert_matching_permissions FILENAME, ZIPNAME
     end
 
   else
@@ -25,7 +25,7 @@ class FilePermissionsTest < MiniTest::Test
 
     def test_current_umask
       create_files
-      assert_equal ::File.stat(FILENAME).mode, ::File.stat(ZIPNAME).mode
+      assert_matching_permissions FILENAME, ZIPNAME
     end
 
     def test_umask_000
@@ -33,7 +33,7 @@ class FilePermissionsTest < MiniTest::Test
         create_files
       end
 
-      assert_equal ::File.stat(FILENAME).mode, ::File.stat(ZIPNAME).mode
+      assert_matching_permissions FILENAME, ZIPNAME
     end
 
     def test_umask_066
@@ -41,7 +41,7 @@ class FilePermissionsTest < MiniTest::Test
         create_files
       end
 
-      assert_equal ::File.stat(FILENAME).mode, ::File.stat(ZIPNAME).mode
+      assert_matching_permissions FILENAME, ZIPNAME
     end
 
     def test_umask_027
@@ -49,9 +49,16 @@ class FilePermissionsTest < MiniTest::Test
         create_files
       end
 
-      assert_equal ::File.stat(FILENAME).mode, ::File.stat(ZIPNAME).mode
+      assert_matching_permissions FILENAME, ZIPNAME
     end
 
+  end
+
+  def assert_matching_permissions(expected_file, actual_file)
+    assert_equal(
+      ::File.stat(expected_file).mode.to_s(8).rjust(4, '0'),
+      ::File.stat(actual_file).mode.to_s(8).rjust(4, '0')
+    )
   end
 
   def create_files

--- a/test/file_permissions_test.rb
+++ b/test/file_permissions_test.rb
@@ -10,48 +10,33 @@ class FilePermissionsTest < MiniTest::Test
     ::File.unlink(FILENAME)
   end
 
-  if ::Zip::RUNNING_ON_WINDOWS
-    # Windows tests
+  def test_current_umask
+    create_files
+    assert_matching_permissions FILENAME, ZIPNAME
+  end
 
-    DEFAULT_PERMS = 0644
-
-    def test_windows_perms
+  def test_umask_000
+    set_umask(0000) do
       create_files
-      assert_matching_permissions FILENAME, ZIPNAME
     end
 
-  else
-    # Unix tests
+    assert_matching_permissions FILENAME, ZIPNAME
+  end
 
-    def test_current_umask
+  def test_umask_066
+    set_umask(0066) do
       create_files
-      assert_matching_permissions FILENAME, ZIPNAME
     end
 
-    def test_umask_000
-      set_umask(0000) do
-        create_files
-      end
+    assert_matching_permissions FILENAME, ZIPNAME
+  end
 
-      assert_matching_permissions FILENAME, ZIPNAME
+  def test_umask_027
+    set_umask(0027) do
+      create_files
     end
 
-    def test_umask_066
-      set_umask(0066) do
-        create_files
-      end
-
-      assert_matching_permissions FILENAME, ZIPNAME
-    end
-
-    def test_umask_027
-      set_umask(0027) do
-        create_files
-      end
-
-      assert_matching_permissions FILENAME, ZIPNAME
-    end
-
+    assert_matching_permissions FILENAME, ZIPNAME
   end
 
   def assert_matching_permissions(expected_file, actual_file)

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -40,6 +40,20 @@ class ZipFileTest < MiniTest::Test
     assert_equal(2, zfRead.entries.length)
   end
 
+  def test_create_from_scratch_with_old_create_parameter
+    comment = 'a short comment'
+
+    zf = ::Zip::File.new(EMPTY_FILENAME, 1)
+    zf.get_output_stream('myFile') { |os| os.write 'myFile contains just this' }
+    zf.mkdir('dir1')
+    zf.comment = comment
+    zf.close
+
+    zfRead = ::Zip::File.new(EMPTY_FILENAME)
+    assert_equal(comment, zfRead.comment)
+    assert_equal(2, zfRead.entries.length)
+  end
+
   def test_get_output_stream
     entryCount = nil
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|


### PR DESCRIPTION
This is an attempt to fix #294 in a more sensible way than was attempted, by me :-), previously.

I used the improved tests by @metavida.

To fix it I stopped the original temporary files from being created with 0600 permissions. Is this sensible? Have I missed something?
