### PR TITLE
remove tr to support cp932 encoding

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -358,7 +358,7 @@ module Zip
       unpack_c_dir_entry(static_sized_fields_buf)
       check_c_dir_entry_signature
       set_time(@last_mod_date, @last_mod_time)
-      @name = io.read(@name_length).tr('\\', '/')
+      @name = io.read(@name_length)
       read_c_dir_extra_field(io)
       @comment = io.read(@comment_length)
       check_c_dir_entry_comment_size


### PR DESCRIPTION
This is a change to support cp932, AKA Windows-31J or Shift_JIS, encoding that is used in Japanese Windows.
There may be Kanji characters that have \x5c byte in their codepoint.
tr consume the byte and make the codepoint invalid.

Here's an example.

```
irb(main):002:0> '表'.encode('windows-31j').bytes.map { |x| x.to_s(16) }
=> ["95", "5c"]                                                                                                          

```