### PR TITLE
Fix deprecated warnings

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,9 +1,9 @@
 require 'coveralls'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
-]
+])
 SimpleCov.start do
   add_filter '/test'
 end

--- a/lib/zip/ioextras/abstract_output_stream.rb
+++ b/lib/zip/ioextras/abstract_output_stream.rb
@@ -20,12 +20,12 @@ module Zip
 
       def putc(an_object)
         self << case an_object
-                when Fixnum
+                when Integer
                   an_object.chr
                 when String
                   an_object
                 else
-                  raise TypeError, 'putc: Only Fixnum and String supported'
+                  raise TypeError, 'putc: Only Integer and String supported'
                 end
         an_object
       end

--- a/test/central_directory_entry_test.rb
+++ b/test/central_directory_entry_test.rb
@@ -37,7 +37,7 @@ class ZipCentralDirectoryEntryTest < MiniTest::Test
       assert_equal('', entry.comment)
 
       entry = ::Zip::Entry.read_c_dir_entry(file)
-      assert_equal(nil, entry)
+      assert_nil(entry)
       # Fields that are not check by this test:
       #          version made by                 2 bytes
       #          version needed to extract       2 bytes

--- a/test/crypto/null_encryption_test.rb
+++ b/test/crypto/null_encryption_test.rb
@@ -18,7 +18,9 @@ class NullEncrypterTest < MiniTest::Test
   end
 
   def test_encrypt
-    [nil, '', 'a' * 10, 0xffffffff].each do |data|
+    assert_nil @encrypter.encrypt(nil)
+
+    ['', 'a' * 10, 0xffffffff].each do |data|
       assert_equal data, @encrypter.encrypt(data)
     end
   end
@@ -42,7 +44,9 @@ class NullDecrypterTest < MiniTest::Test
   end
 
   def test_decrypt
-    [nil, '', 'a' * 10, 0xffffffff].each do |data|
+    assert_nil @decrypter.decrypt(nil)
+
+    ['', 'a' * 10, 0xffffffff].each do |data|
       assert_equal data, @decrypter.decrypt(data)
     end
   end

--- a/test/entry_set_test.rb
+++ b/test/entry_set_test.rb
@@ -76,7 +76,7 @@ class ZipEntrySetTest < MiniTest::Test
     ::Zip.case_insensitive_match = false
     zipEntrySet = ::Zip::EntrySet.new(entries)
     assert_equal(entries[0], zipEntrySet.find_entry('MiXeDcAsEnAmE'))
-    assert_equal(nil, zipEntrySet.find_entry('mixedcasename'))
+    assert_nil(zipEntrySet.find_entry('mixedcasename'))
   end
 
   def test_entries_with_sort
@@ -123,7 +123,7 @@ class ZipEntrySetTest < MiniTest::Test
     ]
     entrySet = ::Zip::EntrySet.new(entries)
 
-    assert_equal(nil, entrySet.parent(entries[0]))
+    assert_nil(entrySet.parent(entries[0]))
     assert_equal(entries[0], entrySet.parent(entries[1]))
     assert_equal(entries[1], entrySet.parent(entries[2]))
   end

--- a/test/entry_test.rb
+++ b/test/entry_test.rb
@@ -109,8 +109,8 @@ class ZipEntryTest < MiniTest::Test
     entry5 = ::Zip::Entry.new('zf.zip', 'aa/bb/cc')
     entry6 = ::Zip::Entry.new('zf.zip', 'aa/bb/cc/')
 
-    assert_equal(nil, entry1.parent_as_string)
-    assert_equal(nil, entry2.parent_as_string)
+    assert_nil(entry1.parent_as_string)
+    assert_nil(entry2.parent_as_string)
     assert_equal('aa/', entry3.parent_as_string)
     assert_equal('aa/', entry4.parent_as_string)
     assert_equal('aa/bb/', entry5.parent_as_string)

--- a/test/filesystem/file_nonmutating_test.rb
+++ b/test/filesystem/file_nonmutating_test.rb
@@ -103,12 +103,12 @@ class ZipFsFileNonmutatingTest < MiniTest::Test
   end
 
   def test_size?
-    assert_equal(nil, @zip_file.file.size?('notAFile'))
+    assert_nil(@zip_file.file.size?('notAFile'))
     assert_equal(72, @zip_file.file.size?('file1'))
-    assert_equal(nil, @zip_file.file.size?('dir2/dir21'))
+    assert_nil(@zip_file.file.size?('dir2/dir21'))
 
     assert_equal(72, @zip_file.file.stat('file1').size?)
-    assert_equal(nil, @zip_file.file.stat('dir2/dir21').size?)
+    assert_nil(@zip_file.file.stat('dir2/dir21').size?)
   end
 
   def test_file?

--- a/test/filesystem/file_stat_test.rb
+++ b/test/filesystem/file_stat_test.rb
@@ -11,7 +11,7 @@ class ZipFsFileStatTest < MiniTest::Test
   end
 
   def test_blocks
-    assert_equal(nil, @zip_file.file.stat('file1').blocks)
+    assert_nil(@zip_file.file.stat('file1').blocks)
   end
 
   def test_ino

--- a/test/input_stream_test.rb
+++ b/test/input_stream_test.rb
@@ -75,12 +75,12 @@ class ZipInputStreamTest < MiniTest::Test
       entry = zis.get_next_entry # empty.txt
       assert_equal(TestZipFile::TEST_ZIP2.entry_names[1], entry.name)
       assert_equal(0, entry.size)
-      assert_equal(nil, zis.gets)
+      assert_nil(zis.gets)
       assert_equal(true, zis.eof?)
       entry = zis.get_next_entry # empty_chmod640.txt
       assert_equal(TestZipFile::TEST_ZIP2.entry_names[2], entry.name)
       assert_equal(0, entry.size)
-      assert_equal(nil, zis.gets)
+      assert_nil(zis.gets)
       assert_equal(true, zis.eof?)
       entry = zis.get_next_entry # short.txt
       assert_equal(TestZipFile::TEST_ZIP2.entry_names[3], entry.name)
@@ -102,12 +102,12 @@ class ZipInputStreamTest < MiniTest::Test
       entry = zis.get_next_entry # empty.txt
       assert_equal(TestZipFile::TEST_ZIP2.entry_names[1], entry.name)
       assert_equal(0, entry.size)
-      assert_equal(nil, zis.gets)
+      assert_nil(zis.gets)
       assert_equal(true, zis.eof?)
       entry = zis.get_next_entry # empty_chmod640.txt
       assert_equal(TestZipFile::TEST_ZIP2.entry_names[2], entry.name)
       assert_equal(0, entry.size)
-      assert_equal(nil, zis.gets)
+      assert_nil(zis.gets)
       assert_equal(true, zis.eof?)
       entry = zis.get_next_entry # short.txt
       assert_equal(TestZipFile::TEST_ZIP2.entry_names[3], entry.name)

--- a/test/ioextras/abstract_input_stream_test.rb
+++ b/test/ioextras/abstract_input_stream_test.rb
@@ -44,7 +44,7 @@ class AbstractInputStreamTest < MiniTest::Test
     assert_equal(2, @io.lineno)
     assert_equal(TEST_LINES[2], @io.gets)
     assert_equal(3, @io.lineno)
-    assert_equal(nil, @io.gets)
+    assert_nil(@io.gets)
     assert_equal(4, @io.lineno)
   end
 

--- a/test/ioextras/fake_io_test.rb
+++ b/test/ioextras/fake_io_test.rb
@@ -12,7 +12,7 @@ class FakeIOTest < MiniTest::Test
     assert(obj.kind_of?(Object))
     assert(obj.kind_of?(FakeIOUsingClass))
     assert(obj.kind_of?(IO))
-    assert(!obj.kind_of?(Fixnum))
+    assert(!obj.kind_of?(Integer))
     assert(!obj.kind_of?(String))
   end
 end

--- a/test/local_entry_test.rb
+++ b/test/local_entry_test.rb
@@ -36,7 +36,7 @@ class ZipLocalEntryTest < MiniTest::Test
 
   def test_read_local_entry_from_non_zip_file
     ::File.open('test/data/file2.txt') do |file|
-      assert_equal(nil, ::Zip::Entry.read_local_entry(file))
+      assert_nil(::Zip::Entry.read_local_entry(file))
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -134,7 +134,7 @@ module AssertEntry
     testZipFile.entry_names.each do |entryName|
       assert_next_entry(entryName, zis)
     end
-    assert_equal(nil, zis.get_next_entry)
+    assert_nil(zis.get_next_entry)
   end
 
   def assert_test_zip_contents(testZipFile)


### PR DESCRIPTION
Fix following deprecated warnings in `rake test`.

- `Use assert_nil if expecting nil`
- `::[] is deprecated. Use ::new instead.`
- `constant ::Fixnum is deprecated` in Ruby 2.4 https://bugs.ruby-lang.org/issues/12005

Thanks.