### PR TITLE
allows open_buffer to work without a given block

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -129,6 +129,7 @@ module Zip
         end
         zf = ::Zip::File.new(io, true, true, options)
         zf.read_from_stream(io)
+        return zf unless block_given?
         yield zf
         begin
           zf.write_buffer(io)

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -104,6 +104,12 @@ class ZipFileTest < MiniTest::Test
     end
   end
 
+  def test_open_buffer_without_block
+    string_io = StringIO.new File.read('test/data/rubycode.zip')
+    zf = ::Zip::File.open_buffer string_io
+    assert zf.entries.map { |e| e.name }.include?('zippedruby1.rb')
+  end
+
   def test_cleans_up_tempfiles_after_close
     zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
     zf.get_output_stream('myFile') do |os|


### PR DESCRIPTION
File::open_buffer should function like open in that a block is optional.  This PR makes open_buffer behave similar to File::open by returning the zf if no block given.