### PR TITLE
Save temporary files to a temporary directory

### DIFF
--- a/lib/zip/streamable_stream.rb
+++ b/lib/zip/streamable_stream.rb
@@ -5,7 +5,7 @@ module Zip
       dirname = if zipfile.is_a?(::String)
                   ::File.dirname(zipfile)
                 else
-                  '.'
+                  nil
                 end
       @temp_file = Tempfile.new(::File.basename(name), dirname)
       @temp_file.binmode


### PR DESCRIPTION
I would like to save temporary files to a temporary directory.

Because the primary objective of `@temp_file` in `Zip::StreamableStream` is to temporarily hold data of an entry as a file, the upper directory does not need to be the current directory.

This patch set the directory to default `Dir.tmpdir`. As a result, we can stop temporary files from filling up current directory.

c.f. http://ruby-doc.org/stdlib-2.4.1/libdoc/tempfile/rdoc/Tempfile.html