### PR TITLE
 Travis: Workaround a rbx-3 autoload issue  WIP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
   - 2.3.5
   - 2.4.2
   - ruby-head
-  - rbx-3
 matrix:
   include:
   - rvm: jruby-9.1.14.0
@@ -17,6 +16,9 @@ matrix:
     jdk: openjdk7
   - rvm: jruby-head
     jdk: oraclejdk8
+  - rvm: rbx-3
+    env:
+      - RUBYOPT="-rbundler/deprecate bundle install"
   allow_failures:
     - rvm: ruby-head
     - rvm: rbx-3

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     jdk: oraclejdk8
   - rvm: rbx-3
     env:
-      - RUBYOPT="-rbundler/deprecate bundle install"
+      - RUBYOPT="-rbundler/deprecate"
   allow_failures:
     - rvm: ruby-head
     - rvm: rbx-3


### PR DESCRIPTION
Rubinius with Bundler 1.16.0 has a problem to do with Rubinius' autoloading behavior.

One Bundler file ('bundler/deprecate') is needed way early, and to make that work on Rubinius, I have opted to use Ruby's `RUBYOPT` environment variable to add a require on the `ruby` command level.

  - see bundler/bundler#6163

**Update:** This makes `bundle install` pass, but `bundle exec rake` still raises a NameError about Bundler::Deprecate.