### PR TITLE
Added fix for calling 'close' on a StringIO-backed zip file, and specs

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -306,7 +306,7 @@ module Zip
     # Commits changes that has been made since the previous commit to
     # the zip archive.
     def commit
-      return unless commit_required?
+      return if name.is_a?(StringIO) || !commit_required?
       on_success_replace do |tmp_file|
         ::Zip::OutputStream.open(tmp_file) do |zos|
           @entry_set.each do |e|

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -104,6 +104,19 @@ class ZipFileTest < MiniTest::Test
     end
   end
 
+  def test_close_buffer_with_stringio
+    string_io = StringIO.new File.read('test/data/rubycode.zip')
+    zf = ::Zip::File.open_buffer string_io
+    assert(zf.close || true) # Poor man's refute_raises
+  end
+
+  def test_close_buffer_with_io
+    f = File.open('test/data/rubycode.zip')
+    zf = ::Zip::File.open_buffer f
+    assert zf.close
+    f.close
+  end
+
   def test_open_buffer_without_block
     string_io = StringIO.new File.read('test/data/rubycode.zip')
     zf = ::Zip::File.open_buffer string_io


### PR DESCRIPTION
Right now if you call `Zip::File#close` on a zipfile that's been opened with a `StringIO` you get an exception in `on_success_replace`.  This fixes this since calling `.close` here should be a no-op anyway as there's no on-disk file to replace.