### PR TITLE
Fix regression caused by automatic Rubocop fixes

### DIFF
--- a/lib/zip/input_stream.rb
+++ b/lib/zip/input_stream.rb
@@ -129,7 +129,7 @@ module Zip
       end
       if @current_entry && @current_entry.gp_flags & 8 == 8 && @current_entry.crc == 0 \
         && @current_entry.compressed_size == 0 \
-        && @current_entry.empty? && !@internal
+        && @current_entry.size == 0 && !@internal
         raise GPFBit3Error,
               'General purpose flag Bit 3 is set so not possible to get proper info from local header.' \
               'Please use ::Zip::File instead of ::Zip::InputStream'


### PR DESCRIPTION
`Zip::Entry.empty?` doesn't exist, but Rubocop suggested it as a fix instead of `size == 0`.  This particular instance only fails under very certain circumstances.  I have a file that causes it to fail but it's an proprietary internal file that's automatically generated by one of our vendors so I'm unable to share it.

I only fixed this one specific instance, there may be other regressions caused by the Rubocop cleanup so perhaps the entire commit should be double-checked.