### PR TITLE
Fix #280 - `open_buffer` mangles the content of the buffer it is given.

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -64,9 +64,9 @@ module Zip
 
     # Opens a zip archive. Pass true as the second parameter to create
     # a new archive if it doesn't exist already.
-    def initialize(file_name, create = false, buffer = false, options = {})
+    def initialize(path_or_io, create = false, buffer = false, options = {})
       super()
-      @name    = file_name
+      @name    = path_or_io.respond_to?(:path) ? path_or_io.path : path_or_io
       @comment = ''
       @create  = create ? true : false # allow any truthy value to mean true
       if !buffer && ::File.size?(@name)

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -134,12 +134,10 @@ module Zip
           raise "Zip::File.open_buffer expects a String or IO-like argument (responds to #{IO_METHODS.join(', ')}). Found: #{io.class}"
         end
 
-        if io.is_a?(::String)
-          io = ::StringIO.new(io)
-        elsif io.respond_to?(:binmode)
-          # https://github.com/rubyzip/rubyzip/issues/119
-          io.binmode
-        end
+        io = ::StringIO.new(io) if io.is_a?(::String)
+
+        # https://github.com/rubyzip/rubyzip/issues/119
+        io.binmode if io.respond_to?(:binmode)
 
         zf = ::Zip::File.new(io, true, true, options)
         return zf unless block_given?

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -120,7 +120,6 @@ module Zip
           raise "Zip::File.open_buffer expects a String or IO-like argument (responds to #{IO_METHODS.join(', ')}). Found: #{io.class}"
         end
         if io.is_a?(::String)
-          require 'stringio'
           io = ::StringIO.new(io)
         elsif io.respond_to?(:binmode)
           # https://github.com/rubyzip/rubyzip/issues/119

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -69,18 +69,18 @@ module Zip
       @name    = file_name
       @comment = ''
       @create  = create ? true : false # allow any truthy value to mean true
-      if !buffer && ::File.size?(file_name)
+      if !buffer && ::File.size?(@name)
         @create = false
-        @file_permissions = ::File.stat(file_name).mode
-        ::File.open(name, 'rb') do |f|
+        @file_permissions = ::File.stat(@name).mode
+        ::File.open(@name, 'rb') do |f|
           read_from_stream(f)
         end
       elsif @create
         @entry_set = EntrySet.new
-      elsif ::File.zero?(file_name)
-        raise Error, "File #{file_name} has zero size. Did you mean to pass the create flag?"
+      elsif ::File.zero?(@name)
+        raise Error, "File #{@name} has zero size. Did you mean to pass the create flag?"
       else
-        raise Error, "File #{file_name} not found"
+        raise Error, "File #{@name} not found"
       end
       @stored_entries      = @entry_set.dup
       @stored_comment      = @comment

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -107,13 +107,14 @@ class ZipFileTest < MiniTest::Test
   def test_close_buffer_with_stringio
     string_io = StringIO.new File.read('test/data/rubycode.zip')
     zf = ::Zip::File.open_buffer string_io
-    assert(zf.close || true) # Poor man's refute_raises
+    assert_nil zf.close
   end
 
   def test_close_buffer_with_io
     f = File.open('test/data/rubycode.zip')
     zf = ::Zip::File.open_buffer f
-    assert zf.close
+    refute zf.commit_required?
+    assert_nil zf.close
     f.close
   end
 

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -97,6 +97,13 @@ class ZipFileTest < MiniTest::Test
     end
   end
 
+  def test_open_buffer_with_string
+    string = File.read('test/data/rubycode.zip')
+    ::Zip::File.open_buffer string do |zf|
+      assert zf.entries.map { |e| e.name }.include?('zippedruby1.rb')
+    end
+  end
+
   def test_open_buffer_with_stringio
     string_io = StringIO.new File.read('test/data/rubycode.zip')
     ::Zip::File.open_buffer string_io do |zf|


### PR DESCRIPTION
Things are now more carefully set up, and if a buffer is passed in which represents a file that already exists then this is taken into account. All initialization is now done in File.new, rather than being split between there and File.open_buffer.

This has also needed a bit of a re-write of Zip::File.initialize. I've tried to bring some logic to it as a result, and have added comments to explain what is now happening.

This PR includes some other related fixes too. All tests pass.