### PR TITLE
Turn off all terminal output in all tests.

### DIFF
--- a/samples/example_recursive.rb
+++ b/samples/example_recursive.rb
@@ -33,7 +33,6 @@ class ZipFileGenerator
     entries.each do |e|
       zipfile_path = path == '' ? e : File.join(path, e)
       disk_file_path = File.join(@input_dir, zipfile_path)
-      puts "Deflating #{disk_file_path}"
 
       if File.directory? disk_file_path
         recursively_deflate_directory(disk_file_path, zipfile, zipfile_path)

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -360,7 +360,7 @@ class ZipFileTest < MiniTest::Test
     zfRead.close
 
     zf.close
-    res = system("unzip -t #{TEST_ZIP.zip_name}")
+    res = system("unzip -tqq #{TEST_ZIP.zip_name}")
     assert_equal(res, true)
   end
 
@@ -376,7 +376,7 @@ class ZipFileTest < MiniTest::Test
     zf2 = ::Zip::File.open(filename)
     assert(zf2.entries.detect { |e| e.name == 'test1.txt' } != nil)
     assert(zf2.entries.detect { |e| e.name == 'test2.txt' } != nil)
-    res = system("unzip -t #{filename}")
+    res = system("unzip -tqq #{filename}")
     assert_equal(res, true)
   end
 

--- a/test/gentestfiles.rb
+++ b/test/gentestfiles.rb
@@ -71,8 +71,8 @@ class TestZipFile
   end
 
   def self.create_test_zips
-    raise "failed to create test zip '#{TEST_ZIP1.zip_name}'" unless system("/usr/bin/zip #{TEST_ZIP1.zip_name} test/data/file2.txt")
-    raise "failed to remove entry from '#{TEST_ZIP1.zip_name}'" unless system("/usr/bin/zip #{TEST_ZIP1.zip_name} -d test/data/file2.txt")
+    raise "failed to create test zip '#{TEST_ZIP1.zip_name}'" unless system("/usr/bin/zip -q #{TEST_ZIP1.zip_name} test/data/file2.txt")
+    raise "failed to remove entry from '#{TEST_ZIP1.zip_name}'" unless system("/usr/bin/zip -q #{TEST_ZIP1.zip_name} -d test/data/file2.txt")
 
     File.open('test/data/generated/empty.txt', 'w') {}
     File.open('test/data/generated/empty_chmod640.txt', 'w') {}
@@ -93,19 +93,19 @@ class TestZipFile
       file << testBinaryPattern << rand << "\0" while file.tell < 6E5
     end
 
-    raise "failed to create test zip '#{TEST_ZIP2.zip_name}'" unless system("/usr/bin/zip #{TEST_ZIP2.zip_name} #{TEST_ZIP2.entry_names.join(' ')}")
+    raise "failed to create test zip '#{TEST_ZIP2.zip_name}'" unless system("/usr/bin/zip -q #{TEST_ZIP2.zip_name} #{TEST_ZIP2.entry_names.join(' ')}")
 
     if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
-      raise "failed to add comment to test zip '#{TEST_ZIP2.zip_name}'" unless system("echo #{TEST_ZIP2.comment}| /usr/bin/zip -z #{TEST_ZIP2.zip_name}\"")
+      raise "failed to add comment to test zip '#{TEST_ZIP2.zip_name}'" unless system("echo #{TEST_ZIP2.comment}| /usr/bin/zip -zq #{TEST_ZIP2.zip_name}\"")
     else
       # without bash system interprets everything after echo as parameters to
       # echo including | zip -z ...
-      raise "failed to add comment to test zip '#{TEST_ZIP2.zip_name}'" unless system("bash -c \"echo #{TEST_ZIP2.comment} | /usr/bin/zip -z #{TEST_ZIP2.zip_name}\"")
+      raise "failed to add comment to test zip '#{TEST_ZIP2.zip_name}'" unless system("bash -c \"echo #{TEST_ZIP2.comment} | /usr/bin/zip -zq #{TEST_ZIP2.zip_name}\"")
     end
 
-    raise "failed to create test zip '#{TEST_ZIP3.zip_name}'" unless system("/usr/bin/zip #{TEST_ZIP3.zip_name} #{TEST_ZIP3.entry_names.join(' ')}")
+    raise "failed to create test zip '#{TEST_ZIP3.zip_name}'" unless system("/usr/bin/zip -q #{TEST_ZIP3.zip_name} #{TEST_ZIP3.entry_names.join(' ')}")
 
-    raise "failed to create test zip '#{TEST_ZIP4.zip_name}'" unless system("/usr/bin/zip #{TEST_ZIP4.zip_name} #{TEST_ZIP4.entry_names.join(' ')}")
+    raise "failed to create test zip '#{TEST_ZIP4.zip_name}'" unless system("/usr/bin/zip -q #{TEST_ZIP4.zip_name} #{TEST_ZIP4.entry_names.join(' ')}")
   rescue
     # If there are any Windows developers wanting to use a command line zip.exe
     # to help create the following files, there's a free one available from

--- a/test/zip64_full_test.rb
+++ b/test/zip64_full_test.rb
@@ -44,7 +44,7 @@ if ENV['FULL_ZIP64_TEST']
       # note: if this fails, be sure you have UnZip version 6.0 or newer
       # as this is the first version to support zip64 extensions
       # but some OSes (*cough* OSX) still bundle a 5.xx release
-      assert system("unzip -t #{test_filename}"), 'third-party zip validation failed'
+      assert system("unzip -tqq #{test_filename}"), 'third-party zip validation failed'
     end
   end
 


### PR DESCRIPTION
Makes things a lot easier when trying to track down bugs.