### PR TITLE
Fix Zip::FileSystem::ZipFsDir#glob

### DIFF
--- a/lib/zip/filesystem.rb
+++ b/lib/zip/filesystem.rb
@@ -573,8 +573,8 @@ module Zip
         @zipFile.get_output_stream(expand_to_entry(fileName), permissionInt, &aProc)
       end
 
-      def glob(*args, &block)
-        @zipFile.glob(*args, &block)
+      def glob(pattern, *flags, &block)
+        @zipFile.glob(expand_to_entry(pattern), *flags, &block)
       end
 
       def read(fileName)

--- a/lib/zip/filesystem.rb
+++ b/lib/zip/filesystem.rb
@@ -573,6 +573,10 @@ module Zip
         @zipFile.get_output_stream(expand_to_entry(fileName), permissionInt, &aProc)
       end
 
+      def glob(*args, &block)
+        @zipFile.glob(*args, &block)
+      end
+
       def read(fileName)
         @zipFile.read(expand_to_entry(fileName))
       end

--- a/test/filesystem/directory_test.rb
+++ b/test/filesystem/directory_test.rb
@@ -109,6 +109,11 @@ class ZipFsDirectoryTest < MiniTest::Test
       zf.dir.glob('globTest/foo/**/*.txt') do |f|
         assert_equal globbed_files[0], f.name
       end
+
+      zf.dir.chdir('globTest/foo')
+      zf.dir.glob('**/*.txt') do |f|
+        assert_equal globbed_files[0], f.name
+      end
     end
   end
 

--- a/test/filesystem/directory_test.rb
+++ b/test/filesystem/directory_test.rb
@@ -3,6 +3,7 @@ require 'zip/filesystem'
 
 class ZipFsDirectoryTest < MiniTest::Test
   TEST_ZIP = 'test/data/generated/zipWithDirs_copy.zip'
+  GLOB_TEST_ZIP = 'test/data/globTest.zip'
 
   def setup
     FileUtils.cp('test/data/zipWithDirs.zip', TEST_ZIP)
@@ -93,11 +94,23 @@ class ZipFsDirectoryTest < MiniTest::Test
     end
   end
 
-  # Globbing not supported yet
-  # def test_glob
-  #  # test alias []-operator too
-  #  fail "implement test"
-  # end
+  def test_glob
+    globbed_files = [
+      'globTest/foo/bar/baz/foo.txt',
+      'globTest/foo.txt',
+      'globTest/food.txt'
+    ]
+
+    ::Zip::File.open(GLOB_TEST_ZIP) do |zf|
+      zf.dir.glob('**/*.txt') do |f|
+        assert globbed_files.include?(f.name)
+      end
+
+      zf.dir.glob('globTest/foo/**/*.txt') do |f|
+        assert_equal globbed_files[0], f.name
+      end
+    end
+  end
 
   def test_open_new
     ::Zip::File.open(TEST_ZIP) do |zf|


### PR DESCRIPTION
This is an attempt to fix #356 by passing through the glob to the underlying implementation. This takes into account the current working directory within the zip archive.