### PR TITLE
Zip::File.add_stored() to add uncompressed files.

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -287,6 +287,13 @@ module Zip
       @entry_set << new_entry
     end
 
+    # Convenience method for adding the contents of a file to the archive
+    # in Stored format (uncompressed)
+    def add_stored(entry, src_path, &continue_on_exists_proc)
+      entry = ::Zip::Entry.new(@name, entry.to_s, nil, nil, nil, nil, ::Zip::Entry::STORED)
+      add(entry, src_path, &continue_on_exists_proc)
+    end
+
     # Removes the specified entry.
     def remove(entry)
       @entry_set.delete(get_entry(entry))

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -204,6 +204,25 @@ class ZipFileTest < MiniTest::Test
                                 zfRead.get_input_stream(entryName) { |zis| zis.read })
   end
 
+  def test_add_stored
+    srcFile = 'test/data/file2.txt'
+    entryName = 'newEntryName.rb'
+    assert(::File.exist?(srcFile))
+    zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
+    zf.add_stored(entryName, srcFile)
+    zf.close
+
+    zfRead = ::Zip::File.new(EMPTY_FILENAME)
+    entry = zfRead.entries.first
+    assert_equal('', zfRead.comment)
+    assert_equal(1, zfRead.entries.length)
+    assert_equal(entryName, entry.name)
+    assert_equal(entry.size, entry.compressed_size)
+    assert_equal(::Zip::Entry::STORED, entry.compression_method)
+    AssertEntry.assert_contents(srcFile,
+                                zfRead.get_input_stream(entryName) { |zis| zis.read })
+  end
+
   def test_recover_permissions_after_add_files_to_archive
     srcZip = TEST_ZIP.zip_name
     ::File.chmod(0o664, srcZip)


### PR DESCRIPTION
Adding uncompressed files to a zip archive can be overly complex, so this convenience method makes it easier. Examples of the confusion caused by the current situation are in #286 and https://github.com/sul-dlss/preservation_catalog/issues/737.
