### PR TITLE
Add test build with frozen strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2.9
   - 2.3.6
   - 2.4.3
-  - 2.5.0
+  - 2.5.1
   - ruby-head
 matrix:
   include:
@@ -17,6 +17,9 @@ matrix:
     jdk: openjdk7
   - rvm: jruby-head
     jdk: oraclejdk8
+  - rvm: ruby-head
+    env:
+      - RUBYOPT="--enable-frozen-string-literal"
   - rvm: rbx-3
     env:
       - RUBYOPT="-rbundler/deprecate"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
   - rvm: ruby-head
     env:
       - RUBYOPT="--enable-frozen-string-literal"
+  - rvm: ruby-head
+    env:
+      - RUBYOPT=""
   - rvm: rbx-3
     env:
       - RUBYOPT="-rbundler/deprecate"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ matrix:
   - rvm: ruby-head
     env:
       - RUBYOPT="--enable-frozen-string-literal"
-  - rvm: ruby-head
-    env:
-      - RUBYOPT=""
   - rvm: rbx-3
     env:
       - RUBYOPT="-rbundler/deprecate"

--- a/lib/zip/filesystem.rb
+++ b/lib/zip/filesystem.rb
@@ -238,14 +238,15 @@ module Zip
       end
 
       def open(fileName, openMode = 'r', permissionInt = 0o644, &block)
-        openMode.delete!('b') # ignore b option
-        case openMode
+        mode = openMode.dup
+        mode.delete!('b') # ignore b option
+        case mode
         when 'r'
           @mappedZip.get_input_stream(fileName, &block)
         when 'w'
           @mappedZip.get_output_stream(fileName, permissionInt, &block)
         else
-          raise StandardError, "openmode '#{openMode} not supported" unless openMode == 'r'
+          raise StandardError, "openmode '#{mode} not supported" unless mode == 'r'
         end
       end
 

--- a/lib/zip/inflater.rb
+++ b/lib/zip/inflater.rb
@@ -3,7 +3,7 @@ module Zip
     def initialize(input_stream, decrypter = NullDecrypter.new)
       super(input_stream)
       @zlib_inflater           = ::Zlib::Inflate.new(-Zlib::MAX_WBITS)
-      @output_buffer           = ''
+      @output_buffer           = String.new('')
       @has_returned_empty_string = false
       @decrypter = decrypter
     end
@@ -38,7 +38,7 @@ module Zip
 
     private
 
-    def internal_produce_input(buf = String.new)
+    def internal_produce_input(buf = String.new(''))
       retried = 0
       begin
         @zlib_inflater.inflate(@decrypter.decrypt(@input_stream.read(Decompressor::CHUNK_SIZE, buf)))

--- a/lib/zip/inflater.rb
+++ b/lib/zip/inflater.rb
@@ -38,7 +38,7 @@ module Zip
 
     private
 
-    def internal_produce_input(buf = '')
+    def internal_produce_input(buf = String.new)
       retried = 0
       begin
         @zlib_inflater.inflate(@decrypter.decrypt(@input_stream.read(Decompressor::CHUNK_SIZE, buf)))

--- a/lib/zip/inflater.rb
+++ b/lib/zip/inflater.rb
@@ -12,7 +12,7 @@ module Zip
       readEverything = number_of_bytes.nil?
       while readEverything || @output_buffer.bytesize < number_of_bytes
         break if internal_input_finished?
-        @output_buffer << internal_produce_input(buf)
+        @output_buffer += internal_produce_input(buf)
       end
       return value_when_finished if @output_buffer.bytesize == 0 && input_finished?
       end_index = number_of_bytes.nil? ? @output_buffer.bytesize : number_of_bytes

--- a/lib/zip/inflater.rb
+++ b/lib/zip/inflater.rb
@@ -8,11 +8,11 @@ module Zip
       @decrypter = decrypter
     end
 
-    def sysread(number_of_bytes = nil, buf = '')
+    def sysread(number_of_bytes = nil, buf = String.new(''))
       readEverything = number_of_bytes.nil?
       while readEverything || @output_buffer.bytesize < number_of_bytes
         break if internal_input_finished?
-        @output_buffer += internal_produce_input(buf)
+        @output_buffer << internal_produce_input(buf)
       end
       return value_when_finished if @output_buffer.bytesize == 0 && input_finished?
       end_index = number_of_bytes.nil? ? @output_buffer.bytesize : number_of_bytes

--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -11,13 +11,13 @@ module Zip
         super
         @lineno        = 0
         @pos           = 0
-        @output_buffer = String.new
+        @output_buffer = String.new('')
       end
 
       attr_accessor :lineno
       attr_reader :pos
 
-      def read(number_of_bytes = nil, buf = '')
+      def read(number_of_bytes = nil, buf = String.new(''))
         buffer = buf.dup
         tbuf = if @output_buffer.bytesize > 0
                  if number_of_bytes <= @output_buffer.bytesize
@@ -27,7 +27,7 @@ module Zip
                    rbuf = sysread(number_of_bytes, buffer)
                    out  = @output_buffer
                    out << rbuf if rbuf
-                   @output_buffer = ''
+                   @output_buffer = String.new('')
                    out
                  end
                else

--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -77,7 +77,7 @@ module Zip
         while (match_index = @output_buffer.index(a_sep_string, buffer_index)).nil? && !over_limit
           buffer_index = [buffer_index, @output_buffer.bytesize - a_sep_string.bytesize].max
           return @output_buffer.empty? ? nil : flush if input_finished?
-          @output_buffer += produce_input
+          @output_buffer << produce_input
           over_limit = (number_of_bytes && @output_buffer.bytesize >= number_of_bytes)
         end
         sep_index = [match_index + a_sep_string.bytesize, number_of_bytes || @output_buffer.bytesize].min
@@ -91,7 +91,7 @@ module Zip
 
       def flush
         ret_val        = @output_buffer
-        @output_buffer = String.new
+        @output_buffer = String.new('')
         ret_val
       end
 

--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -18,20 +18,19 @@ module Zip
       attr_reader :pos
 
       def read(number_of_bytes = nil, buf = String.new(''))
-        buffer = buf.dup
         tbuf = if @output_buffer.bytesize > 0
                  if number_of_bytes <= @output_buffer.bytesize
                    @output_buffer.slice!(0, number_of_bytes)
                  else
                    number_of_bytes -= @output_buffer.bytesize if number_of_bytes
-                   rbuf = sysread(number_of_bytes, buffer)
+                   rbuf = sysread(number_of_bytes, buf)
                    out  = @output_buffer
                    out << rbuf if rbuf
                    @output_buffer = String.new('')
                    out
                  end
                else
-                 sysread(number_of_bytes, buffer)
+                 sysread(number_of_bytes, buf)
                end
 
         if tbuf.nil? || tbuf.empty?
@@ -41,12 +40,12 @@ module Zip
 
         @pos += tbuf.length
 
-        if buffer
-          buffer.replace(tbuf)
+        if buf
+          buf.replace(tbuf)
         else
-          buffer = tbuf
+          buf = tbuf
         end
-        buffer
+        buf
       end
 
       def readlines(a_sep_string = $/)

--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -11,26 +11,27 @@ module Zip
         super
         @lineno        = 0
         @pos           = 0
-        @output_buffer = ''
+        @output_buffer = ''.dup
       end
 
       attr_accessor :lineno
       attr_reader :pos
 
       def read(number_of_bytes = nil, buf = '')
+        buffer = buf.dup
         tbuf = if @output_buffer.bytesize > 0
                  if number_of_bytes <= @output_buffer.bytesize
                    @output_buffer.slice!(0, number_of_bytes)
                  else
                    number_of_bytes -= @output_buffer.bytesize if number_of_bytes
-                   rbuf = sysread(number_of_bytes, buf)
+                   rbuf = sysread(number_of_bytes, buffer)
                    out  = @output_buffer
                    out << rbuf if rbuf
                    @output_buffer = ''
                    out
                  end
                else
-                 sysread(number_of_bytes, buf)
+                 sysread(number_of_bytes, buffer)
                end
 
         if tbuf.nil? || tbuf.empty?
@@ -40,12 +41,12 @@ module Zip
 
         @pos += tbuf.length
 
-        if buf
-          buf.replace(tbuf)
+        if buffer
+          buffer.replace(tbuf)
         else
-          buf = tbuf
+          buffer = tbuf
         end
-        buf
+        buffer
       end
 
       def readlines(a_sep_string = $/)

--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -11,7 +11,7 @@ module Zip
         super
         @lineno        = 0
         @pos           = 0
-        @output_buffer = ''.dup
+        @output_buffer = String.new
       end
 
       attr_accessor :lineno
@@ -77,7 +77,7 @@ module Zip
         while (match_index = @output_buffer.index(a_sep_string, buffer_index)).nil? && !over_limit
           buffer_index = [buffer_index, @output_buffer.bytesize - a_sep_string.bytesize].max
           return @output_buffer.empty? ? nil : flush if input_finished?
-          @output_buffer << produce_input
+          @output_buffer += produce_input
           over_limit = (number_of_bytes && @output_buffer.bytesize >= number_of_bytes)
         end
         sep_index = [match_index + a_sep_string.bytesize, number_of_bytes || @output_buffer.bytesize].min
@@ -91,7 +91,7 @@ module Zip
 
       def flush
         ret_val        = @output_buffer
-        @output_buffer = ''
+        @output_buffer = String.new
         ret_val
       end
 

--- a/test/filesystem/file_nonmutating_test.rb
+++ b/test/filesystem/file_nonmutating_test.rb
@@ -55,7 +55,7 @@ class ZipFsFileNonmutatingTest < MiniTest::Test
                    f.readline.chomp)
     end
     assert(blockCalled)
-    @zip_file.dir.chdir '/'
+    @zip_file.dir.chdir String.new('/')
 
     assert_raises(Errno::ENOENT) do
       @zip_file.file.open('noSuchEntry')

--- a/test/filesystem/file_nonmutating_test.rb
+++ b/test/filesystem/file_nonmutating_test.rb
@@ -55,7 +55,7 @@ class ZipFsFileNonmutatingTest < MiniTest::Test
                    f.readline.chomp)
     end
     assert(blockCalled)
-    @zip_file.dir.chdir String.new('/')
+    @zip_file.dir.chdir '/'
 
     assert_raises(Errno::ENOENT) do
       @zip_file.file.open('noSuchEntry')


### PR DESCRIPTION
In ruby 3 option `--enable-frozen-string-literal` will be enabled by
default.