### PR TITLE
Prevent NoMethodError crash with malformed zip in #time

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -72,7 +72,7 @@ module Zip
     end
 
     def time
-      if @extra['UniversalTime']
+      if @extra['UniversalTime'] && @extra['UniversalTime'].mtime
         @extra['UniversalTime'].mtime
       elsif @extra['NTFS']
         @extra['NTFS'].mtime

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -72,9 +72,9 @@ module Zip
     end
 
     def time
-      if @extra['UniversalTime'] && @extra['UniversalTime'].mtime
+      if @extra['UniversalTime'] && !@extra['UniversalTime'].mtime.nil?
         @extra['UniversalTime'].mtime
-      elsif @extra['NTFS']
+      elsif @extra['NTFS'] && !@extra['NTFS'].mtime.nil?
         @extra['NTFS'].mtime
       else
         # Standard time field in central directory has local time


### PR DESCRIPTION
Hi, I've been testing rubyzip with a Ruby fuzzing tool ([kisaten](https://github.com/zelivans/kisaten)) and found a few bugs. I wrote fixes for all the bugs and sending PRs now.

In this bug it appears that `ExtraField` can leave some members empty (nil), specifically `mtime` for `UniversalTime` and `NTFS`. I don't know if this is expected behavior but I created a specific fix for this issue by checking nil value in the `#time` function, otherwise it raises a `NoMethodError` and crashes the execution.

## Raw crash
```
/home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry.rb:490:in `==': undefined method `dos_equals' for nil:NilClass (NoMethodError)
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry_set.rb:53:in `=='
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry_set.rb:53:in `=='
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:343:in `!='
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:343:in `commit_required?'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:309:in `commit'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:334:in `close'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:102:in `open'
	from zip.rb:3:in `<main>'
```

[Reproduce the crash with this file](https://github.com/zelivans/rubyzip/blob/upload_crashes/crashes/id:000002%2Csig:10%2Csrc:000000%2Cop:flip1%2Cpos:252).
