### PR TITLE
Prevent NoMethodError crash in #read_c_dir_entry

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -375,7 +375,7 @@ module Zip
     end
 
     def read_c_dir_entry(io) #:nodoc:all
-      static_sized_fields_buf = io.read(::Zip::CDIR_ENTRY_STATIC_HEADER_LENGTH)
+      static_sized_fields_buf = io.read(::Zip::CDIR_ENTRY_STATIC_HEADER_LENGTH) || ''
       check_c_dir_entry_static_header_length(static_sized_fields_buf)
       unpack_c_dir_entry(static_sized_fields_buf)
       check_c_dir_entry_signature


### PR DESCRIPTION
Bug found by fuzzing rubyzip.

`io.read(::Zip::CDIR_ENTRY_STATIC_HEADER_LENGTH)` can resolve to nil, resulting in an unhandled `NoMethodError` exception in the `#check_c_dir_entry_static_header_length` method. This can be simply fixed by using an empty string when this variable is nil. This is a quick fix for the issue, decide if this is okay or you want something more comprehensive.

## Raw crash
```
/home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry.rb:355:in `check_c_dir_entry_static_header_length': undefined method `bytesize' for nil:NilClass (NoMethodError)
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry.rb:379:in `read_c_dir_entry'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry.rb:205:in `read_c_dir_entry'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:127:in `block in read_central_directory_entries'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:126:in `times'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:126:in `read_central_directory_entries'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:138:in `read_from_stream'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:76:in `block in initialize'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:75:in `open'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:75:in `initialize'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:97:in `new'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:97:in `open'
	from zip.rb:3:in `<main>'
```

[Reproduce with this file](https://github.com/zelivans/rubyzip/blob/upload_crashes/crashes/id:000000%2Csig:10%2Csrc:000000%2Cop:flip1%2Cpos:251)