### PR TITLE
Prevent TypeError in read_central_directory_entries and use Zip::Error

### DIFF
--- a/lib/zip/central_directory.rb
+++ b/lib/zip/central_directory.rb
@@ -117,6 +117,7 @@ module Zip
     end
 
     def read_central_directory_entries(io) #:nodoc:
+      raise Error, 'Zip consistency problem with central directory entry offset' if @cdir_offset.nil?
       begin
         io.seek(@cdir_offset, IO::SEEK_SET)
       rescue Errno::EINVAL


### PR DESCRIPTION
Bug found by fuzzing rubyzip.

In the `#read_central_directory_entries` method, `@cdir_offset` can be nil resulting in the call to `io.seek` raising an unhandled `TypeError` exception. It appears `@cdir_offset` is set in `#read_e_o_c_d` or `#read_64_e_o_c_d`, but I am not sure that it is considered a failure for it to be set to nil there, so in my fix I threw a `Zip::Error` exception just before trying to use the non-existent cdir_offset. 

## Raw crash
```
/home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:121:in `seek': no implicit conversion from nil to integer (TypeError)
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:121:in `read_central_directory_entries'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:138:in `read_from_stream'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:76:in `block in initialize'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:75:in `open'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:75:in `initialize'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:97:in `new'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:97:in `open'
	from zip.rb:3:in `<main>'
```

[Reproduce with this file](https://github.com/zelivans/rubyzip/blob/upload_crashes/crashes/id:000014%2Csig:10%2Csrc:000000%2Cop:ext_AO%2Cpos:461)