### PR TITLE
Prevent NoMethodError when @name is nil in entry

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -380,7 +380,7 @@ module Zip
       unpack_c_dir_entry(static_sized_fields_buf)
       check_c_dir_entry_signature
       set_time(@last_mod_date, @last_mod_time)
-      @name = io.read(@name_length)
+      @name = io.read(@name_length) || ''
       if ::Zip.force_entry_names_encoding
         @name.force_encoding(::Zip.force_entry_names_encoding)
       end


### PR DESCRIPTION
Bug found by fuzzing rubyzip.

In the `#name_is_directory?` method the `@name` variable is used to check if the entry is a directory. This results in an unhandled `NoMethodError` when `@name` is nil.  In this case `@name` was set in `#read_c_dir_entry`, where I added a quick fix by setting it to an empty string when it would be set to nil.

I do think some more serious refactoring might be needed to prevent bugs like this one from happening  with rubyzip but for now this solves this precise crash.

## Raw crash
```
/home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry.rb:109:in `name_is_directory?': undefined method `end_with?' for nil:NilClass (NoMethodError)
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry.rb:346:in `set_ftype_from_c_dir_entry'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry.rb:390:in `read_c_dir_entry'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry.rb:205:in `read_c_dir_entry'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:127:in `block in read_central_directory_entries'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:126:in `times'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:126:in `read_central_directory_entries'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:138:in `read_from_stream'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:76:in `block in initialize'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:75:in `open'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:75:in `initialize'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:97:in `new'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:97:in `open'
	from zip.rb:3:in `<main>'
```

[Reproduce with this file](https://github.com/zelivans/rubyzip/blob/upload_crashes/crashes/id:000049%2Csig:10%2Csrc:000145%2B000023%2Cop:splice%2Crep:2)