### PR TITLE
Prevent NoMethodError crash when missing data in extra field

### DIFF
--- a/lib/zip/extra_field.rb
+++ b/lib/zip/extra_field.rb
@@ -40,6 +40,9 @@ module Zip
       while i < binstr.bytesize
         id  = binstr[i, 2]
         len = binstr[i + 2, 2].to_s.unpack('v').first
+        unless id && len
+          raise Error, "Failed to parse extra field, missing data"
+        end
         if id && ID_MAP.member?(id)
           extra_field_type_exist(binstr, id, len, i)
         elsif id


### PR DESCRIPTION
Bug found by fuzzing rubyzip.

When creating an `ExtraField` from a binary string, in the `#merge` method there is no check for the `binstr` length, resulting in either `id` or `len` variables possibly being set to nil. I created a quick fix that raises a `Zip::Error` if either of these variables are nil to prevent an unhandled `NoMethodError` when using them.

## Raw crash
```
/home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/extra_field.rb:14:in `extra_field_type_exist': undefined method `+' for nil:NilClass (NoMethodError)
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/extra_field.rb:44:in `merge'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/extra_field.rb:6:in `initialize'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry.rb:373:in `new'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry.rb:373:in `read_c_dir_extra_field'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry.rb:387:in `read_c_dir_entry'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/entry.rb:205:in `read_c_dir_entry'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:127:in `block in read_central_directory_entries'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:126:in `times'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:126:in `read_central_directory_entries'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/central_directory.rb:138:in `read_from_stream'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:76:in `block in initialize'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:75:in `open'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:75:in `initialize'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:97:in `new'
	from /home/ariel/afl-kisaten/private/sandbox/rubyzip/rubyzip/lib/zip/file.rb:97:in `open'
	from zip.rb:3:in `<main>'
```

[Reproduce with this file](https://github.com/zelivans/rubyzip/blob/upload_crashes/crashes/id:000010%2Csig:10%2Csrc:000000%2Cop:arith8%2Cpos:252%2Cval:-21) (extra_field.rb:14) [or this one](https://github.com/zelivans/rubyzip/blob/upload_crashes/crashes/id:000028%2Csig:10%2Csrc:000046%2Cop:arith8%2Cpos:252%2Cval:-12) (extra_field.rb:12)