### PR TITLE
require pathname where it is used

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 module Zip
   class Entry
     STORED   = 0


### PR DESCRIPTION
Lib::Zip::Entry uses Pathname; if the project that is using RubyZip doesn't already require 'pathname', a bizarre error message of the following form will be generated:

    /Users/homedir/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rubyzip-1.2.2/lib/zip/entry.rb:116:in `name_safe?': uninitialized constant Zip::Entry::Pathname (NameError)

As Pathname is used internally, I believe it should be imported from within RubyZip. If there is a better solution to this issue, I'd love to know!