### PR TITLE
fixed FrozenError caused by frozen-string-literal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,10 @@ matrix:
     - rvm: jruby-head
     - rvm: jruby
 before_install:
-  - gem update --system
-  - gem install bundler
+  - "if $(ruby -e 'exit(RUBY_VERSION >= \"2.3.0\")'); then gem update --system; fi"
+  - "if $(ruby -e 'exit(RUBY_VERSION <  \"2.3.0\")'); then gem update --system 2.7.8; fi"
+  - "if $(ruby -e 'exit(RUBY_VERSION >= \"2.3.0\")'); then gem install bundler; fi" 
+  - "if $(ruby -e 'exit(RUBY_VERSION <  \"2.3.0\")'); then gem install bundler --version 1.17.3; fi"
   - gem --version
 before_script:
   - echo `whereis zip`

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -602,7 +602,7 @@ module Zip
         get_input_stream do |is|
           set_extra_attributes_on_path(dest_path)
 
-          buf = ''
+          buf = ''.dup
           while (buf = is.sysread(::Zip::Decompressor::CHUNK_SIZE, buf))
             os << buf
           end

--- a/lib/zip/extra_field.rb
+++ b/lib/zip/extra_field.rb
@@ -26,7 +26,7 @@ module Zip
     end
 
     def create_unknown_item
-      s = ''
+      s = ''.dup
       class << s
         alias_method :to_c_dir_bin, :to_s
         alias_method :to_local_bin, :to_s

--- a/lib/zip/inflater.rb
+++ b/lib/zip/inflater.rb
@@ -3,7 +3,7 @@ module Zip
     def initialize(input_stream, decrypter = NullDecrypter.new)
       super(input_stream)
       @zlib_inflater           = ::Zlib::Inflate.new(-Zlib::MAX_WBITS)
-      @output_buffer           = ''
+      @output_buffer           = ''.dup
       @has_returned_empty_string = false
       @decrypter = decrypter
     end


### PR DESCRIPTION
Hi,

I got FrozenError when I used rubyzip gem with `--enable-frozen-string-literal` option.
```
FrozenError:
       can't modify frozen String, created at C:/Ruby/Ruby25-x64/lib/ruby/gems/2.5.0/gems/rubyzip-1.2.2/lib/zip/entry.rb:605
```
This PR is to fix the above error.
