### PR TITLE
Update supported ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,6 @@ before_script:
 env:
   global:
     - JRUBY_OPTS="--debug"
+    - COVERALLS_PARALLEL=true
+notifications:
+  webhooks: https://coveralls.io/webhook

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ cache: bundler
 rvm:
   - 2.0.0
   - 2.1.10
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
   - ruby-head
 matrix:
   include:
@@ -25,10 +26,6 @@ matrix:
     - rvm: rbx-3
     - rvm: jruby-head
 before_install:
-  - "if $(ruby -e 'exit(RUBY_VERSION >= \"2.3.0\")'); then gem update --system; fi"
-  - "if $(ruby -e 'exit(RUBY_VERSION <  \"2.3.0\")'); then gem update --system 2.7.8; fi"
-  - "if $(ruby -e 'exit(RUBY_VERSION >= \"2.3.0\")'); then gem install bundler; fi"
-  - "if $(ruby -e 'exit(RUBY_VERSION <  \"2.3.0\")'); then gem install bundler --version 1.17.3; fi"
   - gem --version
 before_script:
   - echo `whereis zip`

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,10 @@ matrix:
     - rvm: ruby-head
     - rvm: rbx-3
     - rvm: jruby-head
-    - rvm: jruby
 before_install:
   - "if $(ruby -e 'exit(RUBY_VERSION >= \"2.3.0\")'); then gem update --system; fi"
   - "if $(ruby -e 'exit(RUBY_VERSION <  \"2.3.0\")'); then gem update --system 2.7.8; fi"
-  - "if $(ruby -e 'exit(RUBY_VERSION >= \"2.3.0\")'); then gem install bundler; fi" 
+  - "if $(ruby -e 'exit(RUBY_VERSION >= \"2.3.0\")'); then gem install bundler; fi"
   - "if $(ruby -e 'exit(RUBY_VERSION <  \"2.3.0\")'); then gem install bundler --version 1.17.3; fi"
   - gem --version
 before_script:


### PR DESCRIPTION
Many recent PRs had spurious CI failures due to end of life ruby versions in CI.

1. The (recent) failures were on [`gem update --system`](https://travis-ci.org/rubyzip/rubyzip/jobs/501116591) for old versions of ruby that are end-of-life.

   Ruby versions < 2.3 are now end of life: https://www.ruby-lang.org/en/downloads/branches and 2.3 is itself scheduled to be EOL on 31 Mar 2019.

2. #390 added workarounds to not run `gem update --system` on those old versions. However, looking at git blame, it looks like `gem update --system` was added a long time ago in 2bd6ebea11b64f47158c3553992943b17a8566f0. In #346, 43f01f4631503912b08b6578a64bc406030d9bce mentions that it shouldn't be needed and removes it but then brings it back in cbdea2a3311bdd8c776afa183c1b2d82ad77ddbb (without comment, even though the previous CI run passed without it).

   I have tried removing it again, and it does not seem to be required now --- both JRuby and MRI builds seem OK with just using the default rubygems version. So, in this PR I have removed it.

3. I was instead going drop the EOL versions from travis, but in the [gemspec](https://github.com/rubyzip/rubyzip/blob/master/rubyzip.gemspec) we are still [requiring ruby version `>= 1.9.2`](https://github.com/rubyzip/rubyzip/blob/d40921b9185217b392d73a11fb461383049d7a99/rubyzip.gemspec#L19), so I feel like we should continue testing on older versions until we bump that requirement.

   I found the discussion around https://github.com/rubyzip/rubyzip/pull/254 / https://github.com/rubyzip/rubyzip/pull/256, and it seems several users and contributors are of the opinion that dropping 1.9 from the test matrix, which was done because `rubocop` no longer supported 1.9, should have been a major version bump.

   My reading of [the semver FAQ](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api) is that a major version bump is not required when a dependency is upgraded, but there are [lengthy and interesting discussions](https://www.reddit.com/r/ruby/comments/7vtceq/when_is_it_okay_to_drop_support_for_ruby_versions/) about this, and I could be persuaded otherwise.

   For the moment, with `gem update --system` removed, the old ruby versions are not causing any problems, so I have left them in. If we want to upgrade rubocop again, which I think would be helpful for supporting frozen string literals (#390 / #374), then we may need to drop them or remove rubocop as a dev dependency (it could e.g. go into the Gemfile in a group that would only be installed for some rubies, but this seems like a lot of complexity to support very old ruby versions).

4. I reverted #375 - the underlying JRuby bug now seems to be fixed, so we don't need to ignore it.

5. The other source of spurious CI problems is coveralls: sometimes the coverage numbers drop even though no code has changed. I think we may need to enable parallel build support: http://docs.coveralls.io/parallel-build-webhook --- otherwise, I think there is a race on which build finishes last (usually one of the JRuby builds). I'm not sure about this, but I would like to try it out.