### PR TITLE
CI: update to latest MRI, drop a setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 cache: bundler
 rvm:
   - 2.0.0
@@ -7,8 +6,8 @@ rvm:
   - 2.2.10
   - 2.3.8
   - 2.4.5
-  - 2.5.3
-  - 2.6.0
+  - 2.5.5
+  - 2.6.2
   - ruby-head
 matrix:
   include:


### PR DESCRIPTION
This PR updates the CI matrix to latest versions of Ruby.

Also: 
  - drop unused Travis configuration: sudo: false - see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for historical detail about when it was removed.