### PR TITLE
Fix CI and try rbx-4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,10 @@ matrix:
     jdk: openjdk7
   - rvm: jruby-head
     jdk: oraclejdk8
-  - rvm: rbx-3
-    env:
-      - RUBYOPT="-rbundler/deprecate"
+  - rvm: rbx-4
   allow_failures:
     - rvm: ruby-head
-    - rvm: rbx-3
+    - rvm: rbx-4
     - rvm: jruby-head
 before_install:
   - gem --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: ruby
+dist: trusty
 cache: bundler
 rvm:
-  - 2.0.0
-  - 2.1.10
-  - 2.2.10
-  - 2.3.8
-  - 2.4.5
-  - 2.5.5
-  - 2.6.2
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
   - ruby-head
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
   include:
   - rvm: jruby
     jdk: oraclejdk8
-  - rvm: jruby
+  - rvm: jruby-9.1
     jdk: openjdk7
   - rvm: jruby-head
     jdk: oraclejdk8

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@
 Tooling / Documentation
 
 - Update `example_recursive.rb` in README [#397](https://github.com/rubyzip/rubyzip/pull/397)
-- Fix CI on `trusty` for now, and automatically pick the latest ruby patch version [#399](https://github.com/rubyzip/rubyzip/pull/399)
+- Hold CI at `trusty` for now, automatically pick the latest ruby patch version, use rbx-4 and hold jruby at 9.1 [#399](https://github.com/rubyzip/rubyzip/pull/399)
 
 # 1.2.3
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 Tooling / Documentation
 
 - Update `example_recursive.rb` in README [#397](https://github.com/rubyzip/rubyzip/pull/397)
+- Fix CI on `trusty` for now, and automatically pick the latest ruby patch version [#399](https://github.com/rubyzip/rubyzip/pull/399)
 
 # 1.2.3
 


### PR DESCRIPTION
- Xenial recently became the default `dist` on Travis, which broke the Java builds. Trusty has now reached [end of Standard Support](https://wiki.ubuntu.com/Releases) but not yet end of life.

- For more info on Java changes in Xenial: https://travis-ci.community/t/the-travis-ci-build-could-not-be-completed-due-to-an-error/1345

- Also omit the ruby patch versions so we don't have to keep updating them.

- The rubinius maintainer asked us to move from rbx-3 to rbx-4 in https://github.com/rubinius/rubinius/issues/3811, which is an easy change (on Trusty; on Xenial it [doesn't appear to exist](https://travis-ci.org/rubyzip/rubyzip/jobs/555358450)).

- We had another apparently spurious drop in coverage in coveralls, but it still seems less flaky than it was before https://github.com/rubyzip/rubyzip/pull/392 .

- Edit: jruby 9.2 does not appear to work with JDK7, so I've held jruby at 9.1. 

I'll leave this open for a bit for comment before merging it.