### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/rubyzip.gemspec
+++ b/rubyzip.gemspec
@@ -16,6 +16,13 @@ Gem::Specification.new do |s|
   s.test_files            = Dir.glob('test/**/*')
   s.require_paths         = ['lib']
   s.license               = 'BSD 2-Clause'
+  s.metadata              = {
+    'bug_tracker_uri'   => 'https://github.com/rubyzip/rubyzip/issues',
+    'changelog_uri'     => "https://github.com/rubyzip/rubyzip/blob/v#{s.version}/Changelog.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/rubyzip/#{s.version}",
+    'source_code_uri'   => "https://github.com/rubyzip/rubyzip/tree/v#{s.version}",
+    'wiki_uri'          => 'https://github.com/rubyzip/rubyzip/wiki'
+  }
   s.required_ruby_version = '>= 1.9.2'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'pry', '~> 0.10'


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `wiki_uri` and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/rubyzip and be available via the rubygems API after the next release.