### PR TITLE
Validate entry sizes when extracting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 # X.X.X (Next)
 
+-
+
+# 1.3.0 (Next)
+
+Security
+
+- Add `validate_entry_sizes` option so that callers can trust an entry's reported size when using `extract` [#403](https://github.com/rubyzip/rubyzip/pull/403)
+   - This option defaults to `false` for backward compatibility in this release, but you are strongly encouraged to set it to `true`. It will default to `true` in rubyzip 2.0.
+
+New Feature
+
 - Add `add_stored` method to simplify adding entries without compression [#366](https://github.com/rubyzip/rubyzip/pull/366)
 
 Tooling / Documentation

--- a/README.md
+++ b/README.md
@@ -265,7 +265,13 @@ Zip.warn_invalid_date = false
 
 ### Size Validation
 
-By default, `rubyzip`'s `extract` method checks that an entry's reported uncompressed size is not (significantly) smaller than its actual size. This is to help you protect your application against [zip bombs](https://en.wikipedia.org/wiki/Zip_bomb). Before `extract`ing an entry, you should check that its size is in the range you expect. For example, if your application supports processing up to 100 files at once, each up to 10MiB, your zip extraction code might look like:
+**This setting defaults to `false` in rubyzip 1.3 for backward compatibility, but it will default to `true` in rubyzip 2.0.**
+
+If you set
+```
+Zip.validate_entry_sizes = true
+```
+then `rubyzip`'s `extract` method checks that an entry's reported uncompressed size is not (significantly) smaller than its actual size. This is to help you protect your application against [zip bombs](https://en.wikipedia.org/wiki/Zip_bomb). Before `extract`ing an entry, you should check that its size is in the range you expect. For example, if your application supports processing up to 100 files at once, each up to 10MiB, your zip extraction code might look like:
 
 ```ruby
 MAX_FILE_SIZE = 10 * 1024**2 # 10MiB

--- a/lib/zip.rb
+++ b/lib/zip.rb
@@ -55,7 +55,7 @@ module Zip
     @write_zip64_support = false
     @warn_invalid_date = true
     @case_insensitive_match = false
-    @validate_entry_sizes = true
+    @validate_entry_sizes = false
   end
 
   def setup

--- a/lib/zip.rb
+++ b/lib/zip.rb
@@ -42,7 +42,8 @@ module Zip
                 :write_zip64_support,
                 :warn_invalid_date,
                 :case_insensitive_match,
-                :force_entry_names_encoding
+                :force_entry_names_encoding,
+                :validate_entry_sizes
 
   def reset!
     @_ran_once = false
@@ -54,6 +55,7 @@ module Zip
     @write_zip64_support = false
     @warn_invalid_date = true
     @case_insensitive_match = false
+    @validate_entry_sizes = true
   end
 
   def setup

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -603,9 +603,16 @@ module Zip
         get_input_stream do |is|
           set_extra_attributes_on_path(dest_path)
 
+          bytes_written = 0
           buf = ''.dup
           while (buf = is.sysread(::Zip::Decompressor::CHUNK_SIZE, buf))
             os << buf
+
+            next unless ::Zip.validate_entry_sizes
+            bytes_written += buf.bytesize
+            if bytes_written > size
+              raise ::Zip::EntrySizeError, "Entry #{name} should be #{size}B but is larger when inflated"
+            end
           end
         end
       end

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -604,14 +604,19 @@ module Zip
           set_extra_attributes_on_path(dest_path)
 
           bytes_written = 0
+          warned = false
           buf = ''.dup
           while (buf = is.sysread(::Zip::Decompressor::CHUNK_SIZE, buf))
             os << buf
-
-            next unless ::Zip.validate_entry_sizes
             bytes_written += buf.bytesize
-            if bytes_written > size
-              raise ::Zip::EntrySizeError, "Entry #{name} should be #{size}B but is larger when inflated"
+            if bytes_written > size && !warned
+              message = "Entry #{name} should be #{size}B but is larger when inflated"
+              if ::Zip.validate_entry_sizes
+                raise ::Zip::EntrySizeError, message
+              else
+                puts "WARNING: #{message}"
+                warned = true
+              end
             end
           end
         end

--- a/lib/zip/errors.rb
+++ b/lib/zip/errors.rb
@@ -4,6 +4,7 @@ module Zip
   class DestinationFileExistsError < Error; end
   class CompressionMethodError < Error; end
   class EntryNameError < Error; end
+  class EntrySizeError < Error; end
   class InternalError < Error; end
   class GPFBit3Error < Error; end
 

--- a/test/file_extract_test.rb
+++ b/test/file_extract_test.rb
@@ -10,6 +10,10 @@ class ZipFileExtractTest < MiniTest::Test
     ::File.delete(EXTRACTED_FILENAME) if ::File.exist?(EXTRACTED_FILENAME)
   end
 
+  def teardown
+    ::Zip.reset!
+  end
+
   def test_extract
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
       zf.extract(ENTRY_TO_EXTRACT, EXTRACTED_FILENAME)
@@ -79,5 +83,63 @@ class ZipFileExtractTest < MiniTest::Test
       zf.close
     end
     assert(!File.exist?(outFile))
+  end
+
+  def test_extract_incorrect_size
+    # The uncompressed size fields in the zip file cannot be trusted. This makes
+    # it harder for callers to validate the sizes of the files they are
+    # extracting, which can lead to denial of service. See also
+    # https://en.wikipedia.org/wiki/Zip_bomb
+    Dir.mktmpdir do |tmp|
+      real_zip = File.join(tmp, 'real.zip')
+      fake_zip = File.join(tmp, 'fake.zip')
+      file_name = 'a'
+      true_size = 500_000
+      fake_size = 1
+
+      ::Zip::File.open(real_zip, ::Zip::File::CREATE) do |zf|
+        zf.get_output_stream(file_name) do |os|
+          os.write 'a' * true_size
+        end
+      end
+
+      compressed_size = nil
+      ::Zip::File.open(real_zip) do |zf|
+        a_entry = zf.find_entry(file_name)
+        compressed_size = a_entry.compressed_size
+        assert_equal true_size, a_entry.size
+      end
+
+      true_size_bytes = [compressed_size, true_size, file_name.size].pack('LLS')
+      fake_size_bytes = [compressed_size, fake_size, file_name.size].pack('LLS')
+
+      data = File.binread(real_zip)
+      assert data.include?(true_size_bytes)
+      data.gsub! true_size_bytes, fake_size_bytes
+
+      File.open(fake_zip, 'wb') do |file|
+        file.write data
+      end
+
+      Dir.chdir tmp do
+        ::Zip::File.open(fake_zip) do |zf|
+          a_entry = zf.find_entry(file_name)
+          assert_equal fake_size, a_entry.size
+
+          ::Zip.validate_entry_sizes = false
+          a_entry.extract
+          assert_equal true_size, File.size(file_name)
+          FileUtils.rm file_name
+
+          ::Zip.validate_entry_sizes = true
+          error = assert_raises ::Zip::EntrySizeError do
+            a_entry.extract
+          end
+          assert_equal \
+            'Entry a should be 1B but is larger when inflated',
+            error.message
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix https://github.com/rubyzip/rubyzip/issues/193 ("Protection Against Zip Bombs")

Currently there is no way to safely check how much data the `Zip::Entry#extract` method will actually extract, because the uncompressed size reported in the zip can be spoofed, and the extraction happens in the method where the caller can't check on its progress.

This can lead to denial of service through disk exhaustion if the input is a [zip bomb](https://en.wikipedia.org/wiki/Zip_bomb).

### Approach

The approach taken here is based on the `validateEntrySizes` option for node's [yauzl](https://www.npmjs.com/package/yauzl) unzipping library: rubyzip can check that it doesn't extract (much) more than the expected amount of data, based on the uncompressed size reported in the zip file. That way the caller can check the entry's uncompressed size before extracting and trust that it is not misleading.

The "much" in "much more" above is because rubyzip writes the data in chunks (currently 32KiB), and it may write up to one chunk more than expected, but that should be negligible, and there will be an error that signals that rubyzip wrote more data than expected.

### Impact

Zip files with incorrectly reported uncompressed sizes that worked before will now fail with a `Zip::EntrySizeError`. Like in `yauzl`, the safe behaviour is the default but a flag is provided to allow the caller to (dangerously) skip the checks:
```rb
Zip.validate_entry_sizes = false
```

EDIT: Following discussion below, `false` will be the default in the 1.3 release. We'll default to `true` in 2.0.

I have updated the README to say that the caller should be checking the size before extracting. I also reorganised some of the options, since there are now quite a few.

### Review

I will aim to leave this open for 1 week for review. CC @simonoff @olleolleolle @hainesr who have been active recently.

It probably merits at least a minor version bump.

### Credit

Thanks to the GE Digital Cyber Security Team for providing a proof of concept, which was the basis for the test case.

Thanks to @thejoshwolfe for providing (I think) a good example of how to handle this, in `yauzl`.