### PR TITLE
Remove test files from gem

### DIFF
--- a/rubyzip.gemspec
+++ b/rubyzip.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.platform              = Gem::Platform::RUBY
   s.summary               = 'rubyzip is a ruby module for reading and writing zip files'
   s.files                 = Dir.glob('{samples,lib}/**/*.rb') + %w[README.md TODO Rakefile]
-  s.test_files            = Dir.glob('test/**/*')
   s.require_paths         = ['lib']
   s.license               = 'BSD 2-Clause'
   s.metadata              = {


### PR DESCRIPTION
Remove the `test_files` from the gemspec, because rubyzip's test files are quite large now and include some malicious zip files that trigger virus scanners on machines that have the gem installed.

Fix https://github.com/rubyzip/rubyzip/issues/384 .

The trend in https://github.com/rubygems/rubygems/issues/735 seems to be to remove `test_files` files from the gemspec. There is some good discussion in that ticket about why this may not be the best thing to do long term (pending changes in rubygems to better support test files), but it does seem to be the preferred approach at the moment.

I am planning to add this to the upcoming 2.0 release. I will leave this open for approximately one week for comment.

CC @MaximeDerche @GElkayam 