### PR TITLE
Bump supported ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,16 @@ language: ruby
 dist: trusty
 cache: bundler
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
   - ruby-head
 matrix:
   include:
-  - rvm: jruby
-    jdk: oraclejdk8
-  - rvm: jruby-9.1
-    jdk: openjdk7
+  - rvm: jruby-9.2
+    jdk: openjdk8
   - rvm: jruby-head
-    jdk: oraclejdk8
+    jdk: openjdk8
   - rvm: rbx-4
   allow_failures:
     - rvm: ruby-head

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gem 'zip-zip' # will load compatibility for old rubyzip API.
 
 ## Requirements
 
-- Ruby 1.9.2 or greater
+- Ruby 2.4 or greater (for rubyzip 2.0; use 1.x for older rubies)
 
 ## Installation
 

--- a/rubyzip.gemspec
+++ b/rubyzip.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
     'source_code_uri'   => "https://github.com/rubyzip/rubyzip/tree/v#{s.version}",
     'wiki_uri'          => 'https://github.com/rubyzip/rubyzip/wiki'
   }
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 2.4'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'minitest', '~> 5.4'


### PR DESCRIPTION
Upgrade minimum supported ruby versions to include only supported rubies. This is planned as part of an upcoming major release (2.0).

This will hopefully make CI less fragile, allow us to upgrade our linting system, and allow us to take advantage of newer ruby features.

Fixes https://github.com/rubyzip/rubyzip/issues/404 .

- Ruby 2.3 has been EOL since the [end of March 2019](https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/).
- Support for JRuby 9.1 ended [at the end of 2017](https://github.com/jruby/jruby/wiki/Roadmap).
- JDK7 is still in [extended support](https://en.wikipedia.org/wiki/Java_version_history), but it seems that JRuby has [dropped it from CI](https://github.com/jruby/jruby/blob/37e63e4d57354daa419af9abc26a9b14b8010001/.travis.yml#L29-L30), and it has caused problems recently (#399).
- It would be nice to move from `trusty` to `xenial`, but that currently prevents testing on rbx (https://github.com/rubyzip/rubyzip/pull/399). The [canary rbx-4 build](https://travis-ci.org/rubinius/travis-canary/builds/558292567) still seems to be broken. To be fair, the tests fail on rbx, and we don't fail the build, so we could give up on this and move to trusty now, but so far it doesn't seem to cause other problems.

Users who need older versions of ruby will still be able to use the planned 1.3 release for now.

I have tried to update the README and gemspec to make this clearer (and will update the changelog as part of the next release), to avoid confusion like in #254 .

Edit: I will leave this open for approximately one week for comment.

CC @hainesr @simonoff 