### PR TITLE
Print library warnings to stderr with `warn` (not `puts`).

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -163,7 +163,7 @@ module Zip
     # is passed.
     def extract(dest_path = nil, &block)
       if dest_path.nil? && !name_safe?
-        warn "WARNING: skipped #{@name} as unsafe"
+        warn "WARNING: skipped '#{@name}' as unsafe."
         return self
       end
 
@@ -591,7 +591,7 @@ module Zip
     def set_time(binary_dos_date, binary_dos_time)
       @time = ::Zip::DOSTime.parse_binary_dos_format(binary_dos_date, binary_dos_time)
     rescue ArgumentError
-      warn 'Invalid date/time in zip entry' if ::Zip.warn_invalid_date
+      warn 'WARNING: invalid date/time in zip entry.' if ::Zip.warn_invalid_date
     end
 
     def create_file(dest_path, _continue_on_exists_proc = proc { Zip.continue_on_exists_proc })
@@ -610,7 +610,7 @@ module Zip
             os << buf
             bytes_written += buf.bytesize
             if bytes_written > size && !warned
-              message = "Entry #{name} should be #{size}B but is larger when inflated"
+              message = "entry '#{name}' should be #{size}B, but is larger when inflated."
               if ::Zip.validate_entry_sizes
                 raise ::Zip::EntrySizeError, message
               else
@@ -642,7 +642,7 @@ module Zip
     def create_symlink(dest_path)
       # TODO: Symlinks pose security challenges. Symlink support temporarily
       # removed in view of https://github.com/rubyzip/rubyzip/issues/369 .
-      warn "WARNING: skipped symlink #{dest_path}"
+      warn "WARNING: skipped symlink '#{dest_path}'."
     end
 
     # apply missing data from the zip64 extra information field, if present

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -163,7 +163,7 @@ module Zip
     # is passed.
     def extract(dest_path = nil, &block)
       if dest_path.nil? && !name_safe?
-        puts "WARNING: skipped #{@name} as unsafe"
+        warn "WARNING: skipped #{@name} as unsafe"
         return self
       end
 
@@ -614,7 +614,7 @@ module Zip
               if ::Zip.validate_entry_sizes
                 raise ::Zip::EntrySizeError, message
               else
-                puts "WARNING: #{message}"
+                warn "WARNING: #{message}"
                 warned = true
               end
             end
@@ -642,7 +642,7 @@ module Zip
     def create_symlink(dest_path)
       # TODO: Symlinks pose security challenges. Symlink support temporarily
       # removed in view of https://github.com/rubyzip/rubyzip/issues/369 .
-      puts "WARNING: skipped symlink #{dest_path}"
+      warn "WARNING: skipped symlink #{dest_path}"
     end
 
     # apply missing data from the zip64 extra information field, if present

--- a/lib/zip/extra_field/generic.rb
+++ b/lib/zip/extra_field/generic.rb
@@ -16,7 +16,7 @@ module Zip
         # If nil, start with empty.
         return false
       elsif binstr[0, 2] != self.class.const_get(:HEADER_ID)
-        $stderr.puts 'Warning: weired extra feild header ID. skip parsing'
+        warn 'Warning: weired extra feild header ID. skip parsing'
         return false
       end
       [binstr[2, 2].unpack('v')[0], binstr[4..-1]]

--- a/lib/zip/extra_field/generic.rb
+++ b/lib/zip/extra_field/generic.rb
@@ -16,7 +16,7 @@ module Zip
         # If nil, start with empty.
         return false
       elsif binstr[0, 2] != self.class.const_get(:HEADER_ID)
-        warn 'Warning: weired extra feild header ID. skip parsing'
+        warn 'WARNING: weird extra field header ID. Skip parsing it.'
         return false
       end
       [binstr[2, 2].unpack('v')[0], binstr[4..-1]]

--- a/lib/zip/input_stream.rb
+++ b/lib/zip/input_stream.rb
@@ -103,7 +103,7 @@ module Zip
       end
 
       def open_buffer(filename_or_io, offset = 0)
-        puts 'open_buffer is deprecated!!! Use open instead!'
+        warn 'open_buffer is deprecated!!! Use open instead!'
         open(filename_or_io, offset)
       end
     end

--- a/test/file_extract_test.rb
+++ b/test/file_extract_test.rb
@@ -127,7 +127,9 @@ class ZipFileExtractTest < MiniTest::Test
           assert_equal fake_size, a_entry.size
 
           ::Zip.validate_entry_sizes = false
-          a_entry.extract
+          assert_output('', /.+\'a\'.+1B.+/) do
+            a_entry.extract
+          end
           assert_equal true_size, File.size(file_name)
           FileUtils.rm file_name
 

--- a/test/file_extract_test.rb
+++ b/test/file_extract_test.rb
@@ -136,7 +136,7 @@ class ZipFileExtractTest < MiniTest::Test
             a_entry.extract
           end
           assert_equal \
-            'Entry a should be 1B but is larger when inflated',
+            "entry 'a' should be 1B, but is larger when inflated.",
             error.message
         end
       end

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -80,7 +80,7 @@ class ZipSettingsTest < MiniTest::Test
     test_file = File.join(File.dirname(__FILE__), 'data', 'WarnInvalidDate.zip')
     Zip.warn_invalid_date = true
 
-    assert_output('', /Invalid date\/time in zip entry/) do
+    assert_output('', /invalid date\/time in zip entry/) do
       ::Zip::File.open(test_file) do |_zf|
       end
     end


### PR DESCRIPTION
This has the advantage of consistency and being able to turn them off with, e.g. `-W0`.

Also, make the messages themselves more consistent and check that they are actually output.

(@jdleesmiller I mentioned a while back in another PR that I would work this one up.)