### PR TITLE
Add `options` parameter to `Zip::File.open`.

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -107,8 +107,8 @@ module Zip
       # Same as #new. If a block is passed the ZipFile object is passed
       # to the block and is automatically closed afterwards just as with
       # ruby's builtin File.open method.
-      def open(file_name, create = false)
-        zf = ::Zip::File.new(file_name, create)
+      def open(file_name, create = false, options = {})
+        zf = ::Zip::File.new(file_name, create, false, options)
         return zf unless block_given?
         begin
           yield zf

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -104,9 +104,9 @@ module Zip
     end
 
     class << self
-      # Same as #new. If a block is passed the ZipFile object is passed
-      # to the block and is automatically closed afterwards just as with
-      # ruby's builtin File.open method.
+      # Similar to ::new. If a block is passed the Zip::File object is passed
+      # to the block and is automatically closed afterwards, just as with
+      # ruby's builtin File::open method.
       def open(file_name, create = false, options = {})
         zf = ::Zip::File.new(file_name, create, false, options)
         return zf unless block_given?


### PR DESCRIPTION
I realized when working up #413 to fix #395 that this was missing, and would be much nicer to have than using `Zip::File.new` for most uses.