### PR TITLE
Travis updates and tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: trusty
+dist: xenial
 cache: bundler
 rvm:
   - 2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ matrix:
   include:
   - rvm: jruby-9.2
     jdk: openjdk8
+  - rvm: jruby-9.2
+    jdk: openjdk11
   - rvm: jruby-head
-    jdk: openjdk8
+    jdk: openjdk11
   - rvm: rbx-4
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.6
   - ruby-head
 matrix:
+  fast_finish: true
   include:
   - rvm: jruby-9.2
     jdk: openjdk8


### PR DESCRIPTION
This PR does three things:

* use a later Ubuntu distribution in the tests (Xenial);
* which allows us to specify the next LTS version of OpenJDK (11);
* and, turn on `fast_finish` so that builds are marked as complete as soon as possible.

It still tests with OpenJDK 8 as it's still in support.