### PR TITLE
Quickly fire up a console with 'zip' pre-loaded.

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'zip'
+
+require 'irb'
+IRB.start(__FILE__)


### PR DESCRIPTION
I find myself testing things in `irb` enough that this has proved useful, so I decided to commit it.

It's purely a developer nicety so isn't stored in the gem.