### PR TITLE
Sync options and fix inconsistent behaviour of `Zip::File#get_entry` and `Zip::File#find_entry`.

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -34,7 +34,7 @@ module Zip
       end
       @follow_symlinks = false
 
-      @restore_times       = true
+      @restore_times       = false
       @restore_permissions = false
       @restore_ownership   = false
       # BUG: need an extra field to support uid/gid's

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -376,7 +376,13 @@ module Zip
     # Searches for entry with the specified name. Returns nil if
     # no entry is found. See also get_entry
     def find_entry(entry_name)
-      @entry_set.find_entry(entry_name)
+      selected_entry = @entry_set.find_entry(entry_name)
+      return if selected_entry.nil?
+
+      selected_entry.restore_ownership   = @restore_ownership
+      selected_entry.restore_permissions = @restore_permissions
+      selected_entry.restore_times       = @restore_times
+      selected_entry
     end
 
     # Searches for entries given a glob
@@ -388,10 +394,8 @@ module Zip
     # if no entry is found.
     def get_entry(entry)
       selected_entry = find_entry(entry)
-      raise Errno::ENOENT, entry unless selected_entry
-      selected_entry.restore_ownership   = @restore_ownership
-      selected_entry.restore_permissions = @restore_permissions
-      selected_entry.restore_times       = @restore_times
+      raise Errno::ENOENT, entry if selected_entry.nil?
+
       selected_entry
     end
 

--- a/test/file_options_test.rb
+++ b/test/file_options_test.rb
@@ -75,6 +75,24 @@ class FileOptionsTest < MiniTest::Test
     assert_time_equal(::Time.now, ::File.mtime(EXTPATH_2))
   end
 
+  def test_get_find_consistency
+    testzip = ::File.expand_path(::File.join('data', 'globTest.zip'), __dir__)
+    file_f = ::File.expand_path('f_test.txt', Dir.tmpdir)
+    file_g = ::File.expand_path('g_test.txt', Dir.tmpdir)
+
+    ::Zip::File.open(testzip) do |zip|
+      e1 = zip.find_entry('globTest/food.txt')
+      e1.extract(file_f)
+      e2 = zip.get_entry('globTest/food.txt')
+      e2.extract(file_g)
+    end
+
+    assert_time_equal(::File.mtime(file_f), ::File.mtime(file_g))
+  ensure
+    ::File.unlink(file_f)
+    ::File.unlink(file_g)
+  end
+
   private
 
   # Method to compare file times. DOS times only have 2 second accuracy.

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -653,6 +653,21 @@ class ZipFileTest < MiniTest::Test
     ::Zip::File.open('test/data/test.xls')
   end
 
+  def test_find_get_entry
+    ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
+      assert_nil zf.find_entry('not_in_here.txt')
+
+      refute_nil zf.find_entry('test/data/generated/empty.txt')
+
+      assert_raises(Errno::ENOENT) do
+        zf.get_entry('not_in_here.txt')
+      end
+
+      # Should not raise anything.
+      zf.get_entry('test/data/generated/empty.txt')
+    end
+  end
+
   private
 
   def assert_contains(zf, entryName, filename = entryName)


### PR DESCRIPTION
See #422 for a detailed explanation of what is going on here.

This is the quick fix to ensure things are consistent for now. I will work up a PR with a longer term fix once we've decided what to do about it.