### PR TITLE
Fix frozen error caused by frozen string literal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - ruby-head
 matrix:
   fast_finish: true

--- a/lib/zip/crypto/decrypted_io.rb
+++ b/lib/zip/crypto/decrypted_io.rb
@@ -7,7 +7,7 @@ module Zip
       @decrypter = decrypter
     end
 
-    def read(length = nil, outbuf = '')
+    def read(length = nil, outbuf = +'')
       return ((length.nil? || length.zero?) ? "" : nil) if eof
 
       while length.nil? || (buffer.bytesize < length)

--- a/lib/zip/crypto/decrypted_io.rb
+++ b/lib/zip/crypto/decrypted_io.rb
@@ -25,7 +25,7 @@ module Zip
     end
 
     def buffer
-      @buffer ||= ''.dup
+      @buffer ||= +''
     end
 
     def input_finished?

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -615,7 +615,7 @@ module Zip
         get_input_stream do |is|
           bytes_written = 0
           warned = false
-          buf = ''.dup
+          buf = +''
           while (buf = is.sysread(::Zip::Decompressor::CHUNK_SIZE, buf))
             os << buf
             bytes_written += buf.bytesize

--- a/lib/zip/extra_field.rb
+++ b/lib/zip/extra_field.rb
@@ -26,7 +26,7 @@ module Zip
     end
 
     def create_unknown_item
-      s = ''.dup
+      s = +''
       class << s
         alias_method :to_c_dir_bin, :to_s
         alias_method :to_local_bin, :to_s

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -402,7 +402,7 @@ module Zip
     # Creates a directory
     def mkdir(entryName, permissionInt = 0o755)
       raise Errno::EEXIST, "File exists - #{entryName}" if find_entry(entryName)
-      entryName = +entryName.to_s
+      entryName = entryName.dup.to_s
       entryName << '/' unless entryName.end_with?('/')
       @entry_set << ::Zip::StreamableDirectory.new(@name, entryName, nil, permissionInt)
     end

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -402,7 +402,7 @@ module Zip
     # Creates a directory
     def mkdir(entryName, permissionInt = 0o755)
       raise Errno::EEXIST, "File exists - #{entryName}" if find_entry(entryName)
-      entryName = entryName.dup.to_s
+      entryName = +entryName.to_s
       entryName << '/' unless entryName.end_with?('/')
       @entry_set << ::Zip::StreamableDirectory.new(@name, entryName, nil, permissionInt)
     end

--- a/lib/zip/inflater.rb
+++ b/lib/zip/inflater.rb
@@ -3,7 +3,7 @@ module Zip
     def initialize(*args)
       super
 
-      @buffer = ''.dup
+      @buffer = +''
       @zlib_inflater = ::Zlib::Inflate.new(-Zlib::MAX_WBITS)
     end
 


### PR DESCRIPTION
Hi,

I got `FrozenError` when I use rubyzip gem --enable-frozen-string-literal option.

```
     FrozenError:
       can't modify frozen String: ""
     # ./vendor/bundle/ruby/2.7.0/gems/rubyzip-2.2.0/lib/zip/crypto/decrypted_io.rb:18:in `replace'
     # ./vendor/bundle/ruby/2.7.0/gems/rubyzip-2.2.0/lib/zip/crypto/decrypted_io.rb:18:in `read'
     # ./vendor/bundle/ruby/2.7.0/gems/rubyzip-2.2.0/lib/zip/inflater.rb:32:in `produce_input'
     # ./vendor/bundle/ruby/2.7.0/gems/rubyzip-2.2.0/lib/zip/inflater.rb:15:in `read'
     # ./vendor/bundle/ruby/2.7.0/gems/rubyzip-2.2.0/lib/zip/input_stream.rb:84:in `sysread'
     # ./vendor/bundle/ruby/2.7.0/gems/rubyzip-2.2.0/lib/zip/entry.rb:619:in `block (2 levels) in create_file'
     # ./vendor/bundle/ruby/2.7.0/gems/rubyzip-2.2.0/lib/zip/entry.rb:534:in `get_input_stream'
     # ./vendor/bundle/ruby/2.7.0/gems/rubyzip-2.2.0/lib/zip/entry.rb:615:in `block in create_file'
     # ./vendor/bundle/ruby/2.7.0/gems/rubyzip-2.2.0/lib/zip/entry.rb:614:in `open'
     # ./vendor/bundle/ruby/2.7.0/gems/rubyzip-2.2.0/lib/zip/entry.rb:614:in `create_file'
     # ./vendor/bundle/ruby/2.7.0/gems/rubyzip-2.2.0/lib/zip/entry.rb:182:in `extract'
```

This PR is to fix the above error.