### PR TITLE
Add an option to create temp files in the zip file directory

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -54,7 +54,8 @@ module Zip
     DEFAULT_OPTIONS = {
       restore_ownership:   false,
       restore_permissions: false,
-      restore_times:       false
+      restore_times:       false,
+      use_system_temp_dir: true
     }.freeze
 
     attr_reader :name
@@ -111,6 +112,7 @@ module Zip
       @restore_ownership   = options[:restore_ownership]
       @restore_permissions = options[:restore_permissions]
       @restore_times       = options[:restore_times]
+      @use_system_temp_dir = options[:use_system_temp_dir]
     end
 
     class << self
@@ -272,7 +274,7 @@ module Zip
               "cannot open stream to directory entry - '#{new_entry}'"
       end
       new_entry.unix_perms = permission_int
-      zip_streamable_entry = StreamableStream.new(new_entry)
+      zip_streamable_entry = StreamableStream.new(new_entry, @use_system_temp_dir)
       @entry_set << zip_streamable_entry
       zip_streamable_entry.get_output_stream(&aProc)
     end

--- a/lib/zip/streamable_stream.rb
+++ b/lib/zip/streamable_stream.rb
@@ -1,8 +1,13 @@
 module Zip
   class StreamableStream < DelegateClass(Entry) # nodoc:all
-    def initialize(entry)
+    def initialize(entry, use_system_temp_dir)
       super(entry)
-      @temp_file = Tempfile.new(::File.basename(name))
+      dirname = if use_system_temp_dir == false && zipfile.is_a?(::String)
+                   ::File.dirname(zipfile)
+                 else
+                   nil
+                 end
+      @temp_file = Tempfile.new(::File.basename(name), dirname)
       @temp_file.binmode
     end
 

--- a/test/streamable_stream_test.rb
+++ b/test/streamable_stream_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class FakeEntry
+  def name
+    'something'
+  end
+
+  def zipfile
+    'data/important_stuff.zip'
+  end
+end
+
+class StreamableStreamTest < MiniTest::Test
+  def test_use_system_temp_dir_true
+    entry = FakeEntry.new
+    stream = ::Zip::StreamableStream.new(entry, true)
+    stream.get_output_stream do |temp_file|
+      assert(temp_file.path.start_with?(Dir.tmpdir))
+    end
+  end
+
+  def test_use_system_temp_dir_false
+    entry = FakeEntry.new
+    FileUtils.mkdir_p(File.dirname(entry.zipfile))
+    stream = ::Zip::StreamableStream.new(entry, false)
+    stream.get_output_stream do |temp_file|
+      assert(temp_file.path.start_with?('data/'))
+    end
+    FileUtils.rm_r(File.dirname(entry.zipfile))
+  end
+end


### PR DESCRIPTION
Before zip files were created in the system temporary directory they
were created in the same directory as the zip file. This adds an option
to have the same behaviour as before by passing in
`use_system_temp_dir: false` as an option to `Zip.open`, which passes
that down to `Zip::StreamableStream`.

See #411 for discussion leading up to this PR.

I didn't see an obvious way to test that `Zip::File` passes the option down to `Zip::StreamableStream` but am happy to add such a test with a bit of direction from the core maintainers.