### PR TITLE
Rubocop name cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,12 +50,6 @@ Metrics/MethodLength:
   Exclude:
     - 'test/**/*.rb'
 
-# Rubocop confuses these as instances of "memoization".
-Naming/MemoizedInstanceVariableName:
-  Exclude:
-    - 'lib/zip/extra_field/old_unix.rb'
-    - 'lib/zip/extra_field/unix.rb'
-
 # Set a consistent way of checking types.
 Style/ClassCheck:
   EnforcedStyle: kind_of?

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,19 +38,6 @@ Naming/AccessorMethodName:
     - 'lib/zip/streamable_stream.rb'
     - 'test/file_permissions_test.rb'
 
-# Offense count: 18
-# Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
-Naming/BlockParameterName:
-  Exclude:
-    - 'lib/zip/file.rb'
-    - 'lib/zip/filesystem.rb'
-    - 'samples/zipfind.rb'
-    - 'test/central_directory_test.rb'
-    - 'test/file_extract_directory_test.rb'
-    - 'test/file_extract_test.rb'
-    - 'test/output_stream_test.rb'
-    - 'test/test_helper.rb'
-
 # Offense count: 140
 # Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
 # AllowedNames: io, id, to, by, on, in, at, ip, db, os

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,13 +38,6 @@ Naming/AccessorMethodName:
     - 'lib/zip/streamable_stream.rb'
     - 'test/file_permissions_test.rb'
 
-# Offense count: 721
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: snake_case, camelCase
-Naming/VariableName:
-  Exclude:
-    - 'lib/**/*.rb'
-
 # Offense count: 7
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: inline, group

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -38,13 +38,6 @@ Naming/AccessorMethodName:
     - 'lib/zip/streamable_stream.rb'
     - 'test/file_permissions_test.rb'
 
-# Offense count: 140
-# Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
-# AllowedNames: io, id, to, by, on, in, at, ip, db, os
-Naming/MethodParameterName:
-  Exclude:
-    - 'lib/**/*.rb'
-
 # Offense count: 721
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: snake_case, camelCase

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -36,7 +36,6 @@ Naming/AccessorMethodName:
     - 'lib/zip/filesystem.rb'
     - 'lib/zip/input_stream.rb'
     - 'lib/zip/streamable_stream.rb'
-    - 'test/file_permissions_test.rb'
 
 # Offense count: 7
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -42,7 +42,9 @@ Naming/AccessorMethodName:
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: snake_case, camelCase
 Naming/VariableName:
-  Enabled: false
+  Exclude:
+    - 'lib/**/*.rb'
+    - 'test/**/*.rb'
 
 # Offense count: 7
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -44,7 +44,6 @@ Naming/AccessorMethodName:
 Naming/MethodParameterName:
   Exclude:
     - 'lib/**/*.rb'
-    - 'test/**/*.rb'
 
 # Offense count: 721
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -42,7 +42,9 @@ Naming/AccessorMethodName:
 # Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
 # AllowedNames: io, id, to, by, on, in, at, ip, db, os
 Naming/MethodParameterName:
-  Enabled: false
+  Exclude:
+    - 'lib/**/*.rb'
+    - 'test/**/*.rb'
 
 # Offense count: 721
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -44,7 +44,6 @@ Naming/AccessorMethodName:
 Naming/VariableName:
   Exclude:
     - 'lib/**/*.rb'
-    - 'test/**/*.rb'
 
 # Offense count: 7
 # Configuration parameters: EnforcedStyle.

--- a/lib/zip/central_directory.rb
+++ b/lib/zip/central_directory.rb
@@ -181,8 +181,8 @@ module Zip
     end
 
     # For iterating over the entries.
-    def each(&proc)
-      @entry_set.each(&proc)
+    def each(&a_proc)
+      @entry_set.each(&a_proc)
     end
 
     # Returns the number of entries in the central directory (and

--- a/lib/zip/crypto/traditional_encryption.rb
+++ b/lib/zip/crypto/traditional_encryption.rb
@@ -24,8 +24,8 @@ module Zip
       end
     end
 
-    def update_keys(n)
-      @key0 = ~Zlib.crc32(n, ~@key0)
+    def update_keys(num)
+      @key0 = ~Zlib.crc32(num, ~@key0)
       @key1 = ((@key1 + (@key0 & 0xff)) * 134_775_813 + 1) & 0xffffffff
       @key2 = ~Zlib.crc32((@key1 >> 24).chr, ~@key2)
     end
@@ -63,10 +63,10 @@ module Zip
 
     private
 
-    def encode(n)
+    def encode(num)
       t = decrypt_byte
-      update_keys(n.chr)
-      t ^ n
+      update_keys(num.chr)
+      t ^ num
     end
   end
 
@@ -86,10 +86,10 @@ module Zip
 
     private
 
-    def decode(n)
-      n ^= decrypt_byte
-      update_keys(n.chr)
-      n
+    def decode(num)
+      num ^= decrypt_byte
+      update_keys(num.chr)
+      num
     end
   end
 end

--- a/lib/zip/dos_time.rb
+++ b/lib/zip/dos_time.rb
@@ -34,13 +34,13 @@ module Zip
       local(time.year, time.month, time.day, time.hour, time.min, time.sec)
     end
 
-    def self.parse_binary_dos_format(binaryDosDate, binaryDosTime)
-      second = 2 * (0b11111 & binaryDosTime)
-      minute = (0b11111100000 & binaryDosTime) >> 5
-      hour   = (0b1111100000000000 & binaryDosTime) >> 11
-      day    = (0b11111 & binaryDosDate)
-      month  = (0b111100000 & binaryDosDate) >> 5
-      year   = ((0b1111111000000000 & binaryDosDate) >> 9) + 1980
+    def self.parse_binary_dos_format(bin_dos_date, bin_dos_time)
+      second = 2 * (0b11111 & bin_dos_time)
+      minute = (0b11111100000 & bin_dos_time) >> 5
+      hour   = (0b1111100000000000 & bin_dos_time) >> 11
+      day    = (0b11111 & bin_dos_date)
+      month  = (0b111100000 & bin_dos_date) >> 5
+      year   = ((0b1111111000000000 & bin_dos_date) >> 9) + 1980
       begin
         local(year, month, day, hour, minute, second)
       end

--- a/lib/zip/extra_field.rb
+++ b/lib/zip/extra_field.rb
@@ -6,23 +6,23 @@ module Zip
       merge(binstr) if binstr
     end
 
-    def extra_field_type_exist(binstr, id, len, i)
+    def extra_field_type_exist(binstr, id, len, index)
       field_name = ID_MAP[id].name
       if member?(field_name)
-        self[field_name].merge(binstr[i, len + 4])
+        self[field_name].merge(binstr[index, len + 4])
       else
-        field_obj        = ID_MAP[id].new(binstr[i, len + 4])
+        field_obj        = ID_MAP[id].new(binstr[index, len + 4])
         self[field_name] = field_obj
       end
     end
 
-    def extra_field_type_unknown(binstr, len, i)
+    def extra_field_type_unknown(binstr, len, index)
       create_unknown_item unless self['Unknown']
-      if !len || len + 4 > binstr[i..-1].bytesize
-        self['Unknown'] << binstr[i..-1]
+      if !len || len + 4 > binstr[index..-1].bytesize
+        self['Unknown'] << binstr[index..-1]
         return
       end
-      self['Unknown'] << binstr[i, len + 4]
+      self['Unknown'] << binstr[index, len + 4]
     end
 
     def create_unknown_item

--- a/lib/zip/extra_field/old_unix.rb
+++ b/lib/zip/extra_field/old_unix.rb
@@ -25,7 +25,7 @@ module Zip
       @uid ||= uid
       @gid ||= gid
       @atime ||= atime
-      @mtime ||= mtime
+      @mtime ||= mtime # rubocop:disable Naming/MemoizedInstanceVariableName
     end
 
     def ==(other)

--- a/lib/zip/extra_field/unix.rb
+++ b/lib/zip/extra_field/unix.rb
@@ -21,7 +21,7 @@ module Zip
 
       uid, gid = content.unpack('vv')
       @uid ||= uid
-      @gid ||= gid
+      @gid ||= gid # rubocop:disable Naming/MemoizedInstanceVariableName
     end
 
     def ==(other)

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -319,11 +319,11 @@ module Zip
 
     # Renames the specified entry.
     def rename(entry, new_name, &continue_on_exists_proc)
-      foundEntry = get_entry(entry)
+      found_entry = get_entry(entry)
       check_entry_exists(new_name, continue_on_exists_proc, 'rename')
-      @entry_set.delete(foundEntry)
-      foundEntry.name = new_name
-      @entry_set << foundEntry
+      @entry_set.delete(found_entry)
+      found_entry.name = new_name
+      @entry_set << found_entry
     end
 
     # Replaces the specified entry with the contents of src_path (from
@@ -420,15 +420,15 @@ module Zip
     private
 
     def directory?(new_entry, src_path)
-      srcPathIsDirectory = ::File.directory?(src_path)
-      if new_entry.directory? && !srcPathIsDirectory
+      path_is_directory = ::File.directory?(src_path)
+      if new_entry.directory? && !path_is_directory
         raise ArgumentError,
               "entry name '#{new_entry}' indicates directory entry, but " \
                   "'#{src_path}' is not a directory"
-      elsif !new_entry.directory? && srcPathIsDirectory
+      elsif !new_entry.directory? && path_is_directory
         new_entry.name += '/'
       end
-      new_entry.directory? && srcPathIsDirectory
+      new_entry.directory? && path_is_directory
     end
 
     def check_entry_exists(entry_name, continue_on_exists_proc, proc_name)

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -169,8 +169,8 @@ module Zip
       # local entry headers (which contain the same information as the
       # central directory).
       def foreach(aZipFileName, &block)
-        ::Zip::File.open(aZipFileName) do |zipFile|
-          zipFile.each(&block)
+        ::Zip::File.open(aZipFileName) do |zip_file|
+          zip_file.each(&block)
         end
       end
 

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -168,8 +168,8 @@ module Zip
       # whereas ZipInputStream jumps through the entire archive accessing the
       # local entry headers (which contain the same information as the
       # central directory).
-      def foreach(aZipFileName, &block)
-        ::Zip::File.open(aZipFileName) do |zip_file|
+      def foreach(zip_file_name, &block)
+        ::Zip::File.open(zip_file_name) do |zip_file|
           zip_file.each(&block)
         end
       end
@@ -255,8 +255,8 @@ module Zip
     # Returns an input stream to the specified entry. If a block is passed
     # the stream object is passed to the block and the stream is automatically
     # closed afterwards just as with ruby's builtin File.open method.
-    def get_input_stream(entry, &aProc)
-      get_entry(entry).get_input_stream(&aProc)
+    def get_input_stream(entry, &a_proc)
+      get_entry(entry).get_input_stream(&a_proc)
     end
 
     # Returns an output stream to the specified entry. If entry is not an instance
@@ -267,7 +267,7 @@ module Zip
     def get_output_stream(entry, permission_int = nil, comment = nil,
                           extra = nil, compressed_size = nil, crc = nil,
                           compression_method = nil, size = nil, time = nil,
-                          &aProc)
+                          &a_proc)
 
       new_entry =
         if entry.kind_of?(Entry)
@@ -282,7 +282,7 @@ module Zip
       new_entry.unix_perms = permission_int
       zip_streamable_entry = StreamableStream.new(new_entry)
       @entry_set << zip_streamable_entry
-      zip_streamable_entry.get_output_stream(&aProc)
+      zip_streamable_entry.get_output_stream(&a_proc)
     end
 
     # Returns the name of the zip archive
@@ -326,12 +326,12 @@ module Zip
       @entry_set << foundEntry
     end
 
-    # Replaces the specified entry with the contents of srcPath (from
+    # Replaces the specified entry with the contents of src_path (from
     # the file system).
-    def replace(entry, srcPath)
-      check_file(srcPath)
+    def replace(entry, src_path)
+      check_file(src_path)
       remove(entry)
-      add(entry, srcPath)
+      add(entry, src_path)
     end
 
     # Extracts entry to file dest_path.
@@ -409,37 +409,37 @@ module Zip
     end
 
     # Creates a directory
-    def mkdir(entryName, permissionInt = 0o755)
-      raise Errno::EEXIST, "File exists - #{entryName}" if find_entry(entryName)
+    def mkdir(entry_name, permission = 0o755)
+      raise Errno::EEXIST, "File exists - #{entry_name}" if find_entry(entry_name)
 
-      entryName = entryName.dup.to_s
-      entryName << '/' unless entryName.end_with?('/')
-      @entry_set << ::Zip::StreamableDirectory.new(@name, entryName, nil, permissionInt)
+      entry_name = entry_name.dup.to_s
+      entry_name << '/' unless entry_name.end_with?('/')
+      @entry_set << ::Zip::StreamableDirectory.new(@name, entry_name, nil, permission)
     end
 
     private
 
-    def directory?(newEntry, srcPath)
-      srcPathIsDirectory = ::File.directory?(srcPath)
-      if newEntry.directory? && !srcPathIsDirectory
+    def directory?(new_entry, src_path)
+      srcPathIsDirectory = ::File.directory?(src_path)
+      if new_entry.directory? && !srcPathIsDirectory
         raise ArgumentError,
-              "entry name '#{newEntry}' indicates directory entry, but " \
-                  "'#{srcPath}' is not a directory"
-      elsif !newEntry.directory? && srcPathIsDirectory
-        newEntry.name += '/'
+              "entry name '#{new_entry}' indicates directory entry, but " \
+                  "'#{src_path}' is not a directory"
+      elsif !new_entry.directory? && srcPathIsDirectory
+        new_entry.name += '/'
       end
-      newEntry.directory? && srcPathIsDirectory
+      new_entry.directory? && srcPathIsDirectory
     end
 
-    def check_entry_exists(entryName, continue_on_exists_proc, procedureName)
+    def check_entry_exists(entry_name, continue_on_exists_proc, proc_name)
       continue_on_exists_proc ||= proc { Zip.continue_on_exists_proc }
-      return unless @entry_set.include?(entryName)
+      return unless @entry_set.include?(entry_name)
 
       if continue_on_exists_proc.call
-        remove get_entry(entryName)
+        remove get_entry(entry_name)
       else
         raise ::Zip::EntryExistsError,
-              procedureName + " failed. Entry #{entryName} already exists"
+              proc_name + " failed. Entry #{entry_name} already exists"
       end
     end
 

--- a/lib/zip/filesystem.rb
+++ b/lib/zip/filesystem.rb
@@ -265,8 +265,8 @@ module Zip
       end
 
       def chown(ownerInt, groupInt, *filenames)
-        filenames.each do |fileName|
-          e = get_entry(fileName)
+        filenames.each do |filename|
+          e = get_entry(filename)
           e.extra.create('IUnix') unless e.extra.member?('IUnix')
           e.extra['IUnix'].uid = ownerInt
           e.extra['IUnix'].gid = groupInt
@@ -275,8 +275,8 @@ module Zip
       end
 
       def chmod(modeInt, *filenames)
-        filenames.each do |fileName|
-          e = get_entry(fileName)
+        filenames.each do |filename|
+          e = get_entry(filename)
           e.fstype = 3 # force convertion filesystem type to unix
           e.unix_perms = modeInt
           e.external_file_attributes = modeInt << 16
@@ -314,8 +314,8 @@ module Zip
       end
 
       def utime(modifiedTime, *fileNames)
-        fileNames.each do |fileName|
-          get_entry(fileName).time = modifiedTime
+        fileNames.each do |filename|
+          get_entry(filename).time = modifiedTime
         end
       end
 
@@ -406,12 +406,12 @@ module Zip
       end
 
       def delete(*args)
-        args.each do |fileName|
-          if directory?(fileName)
-            raise Errno::EISDIR, "Is a directory - \"#{fileName}\""
+        args.each do |filename|
+          if directory?(filename)
+            raise Errno::EISDIR, "Is a directory - \"#{filename}\""
           end
 
-          @mappedZip.remove(fileName)
+          @mappedZip.remove(filename)
         end
       end
 
@@ -488,8 +488,8 @@ module Zip
         path << '/' unless path.end_with?('/')
         path = Regexp.escape(path)
         subDirEntriesRegex = Regexp.new("^#{path}([^/]+)$")
-        @mappedZip.each do |fileName|
-          match = subDirEntriesRegex.match(fileName)
+        @mappedZip.each do |filename|
+          match = subDirEntriesRegex.match(filename)
           yield(match[1]) unless match.nil?
         end
       end

--- a/lib/zip/filesystem.rb
+++ b/lib/zip/filesystem.rb
@@ -444,16 +444,16 @@ module Zip
       end
 
       def open(directory_name)
-        dirIt = new(directory_name)
+        dir_iter = new(directory_name)
         if block_given?
           begin
-            yield(dirIt)
+            yield(dir_iter)
             return nil
           ensure
-            dirIt.close
+            dir_iter.close
           end
         end
-        dirIt
+        dir_iter
       end
 
       def pwd
@@ -487,9 +487,9 @@ module Zip
         path = @file.expand_path(directory_name)
         path << '/' unless path.end_with?('/')
         path = Regexp.escape(path)
-        subDirEntriesRegex = Regexp.new("^#{path}([^/]+)$")
+        subdir_entry_regex = Regexp.new("^#{path}([^/]+)$")
         @mapped_zip.each do |filename|
-          match = subDirEntriesRegex.match(filename)
+          match = subdir_entry_regex.match(filename)
           yield(match[1]) unless match.nil?
         end
       end

--- a/lib/zip/filesystem.rb
+++ b/lib/zip/filesystem.rb
@@ -35,25 +35,25 @@ module Zip
 
   module FileSystem
     def initialize # :nodoc:
-      mappedZip      = ZipFileNameMapper.new(self)
-      @zipFsDir      = ZipFsDir.new(mappedZip)
-      @zipFsFile     = ZipFsFile.new(mappedZip)
-      @zipFsDir.file = @zipFsFile
-      @zipFsFile.dir = @zipFsDir
+      mapped_zip       = ZipFileNameMapper.new(self)
+      @zip_fs_dir      = ZipFsDir.new(mapped_zip)
+      @zip_fs_file     = ZipFsFile.new(mapped_zip)
+      @zip_fs_dir.file = @zip_fs_file
+      @zip_fs_file.dir = @zip_fs_dir
     end
 
     # Returns a ZipFsDir which is much like ruby's builtin Dir (class)
     # object, except it works on the Zip::File on which this method is
     # invoked
     def dir
-      @zipFsDir
+      @zip_fs_dir
     end
 
     # Returns a ZipFsFile which is much like ruby's builtin File (class)
     # object, except it works on the Zip::File on which this method is
     # invoked
     def file
-      @zipFsFile
+      @zip_fs_file
     end
 
     # Instances of this class are normally accessed via the accessor
@@ -72,20 +72,20 @@ module Zip
             methods.each do |method|
               class_eval <<-END_EVAL, __FILE__, __LINE__ + 1
                 def #{method}                      # def file?
-                  @zipFsFile.#{method}(@entryName) #   @zipFsFile.file?(@entryName)
+                  @zip_fs_file.#{method}(@entry_name) #   @zip_fs_file.file?(@entry_name)
                 end                                # end
               END_EVAL
             end
           end
         end
 
-        def initialize(zipFsFile, entryName)
-          @zipFsFile = zipFsFile
-          @entryName = entryName
+        def initialize(zip_fs_file, entry_name)
+          @zip_fs_file = zip_fs_file
+          @entry_name = entry_name
         end
 
-        def kind_of?(t)
-          super || t == ::File::Stat
+        def kind_of?(type)
+          super || type == ::File::Stat
         end
 
         delegate_to_fs_file :file?, :directory?, :pipe?, :chardev?, :symlink?,
@@ -98,7 +98,7 @@ module Zip
         end
 
         def get_entry
-          @zipFsFile.__send__(:get_entry, @entryName)
+          @zip_fs_file.__send__(:get_entry, @entry_name)
         end
         private :get_entry
 
@@ -168,29 +168,29 @@ module Zip
         end
       end
 
-      def initialize(mappedZip)
-        @mappedZip = mappedZip
+      def initialize(mapped_zip)
+        @mapped_zip = mapped_zip
       end
 
-      def get_entry(fileName)
-        unless exists?(fileName)
-          raise Errno::ENOENT, "No such file or directory - #{fileName}"
+      def get_entry(filename)
+        unless exists?(filename)
+          raise Errno::ENOENT, "No such file or directory - #{filename}"
         end
 
-        @mappedZip.find_entry(fileName)
+        @mapped_zip.find_entry(filename)
       end
       private :get_entry
 
-      def unix_mode_cmp(fileName, mode)
-        e = get_entry(fileName)
+      def unix_mode_cmp(filename, mode)
+        e = get_entry(filename)
         e.fstype == 3 && ((e.external_file_attributes >> 16) & mode) != 0
       rescue Errno::ENOENT
         false
       end
       private :unix_mode_cmp
 
-      def exists?(fileName)
-        expand_path(fileName) == '/' || !@mappedZip.find_entry(fileName).nil?
+      def exists?(filename)
+        expand_path(filename) == '/' || !@mapped_zip.find_entry(filename).nil?
       end
       alias exist? exists?
 
@@ -198,133 +198,133 @@ module Zip
       alias owned? exists?
       alias grpowned? exists?
 
-      def readable?(fileName)
-        unix_mode_cmp(fileName, 0o444)
+      def readable?(filename)
+        unix_mode_cmp(filename, 0o444)
       end
       alias readable_real? readable?
 
-      def writable?(fileName)
-        unix_mode_cmp(fileName, 0o222)
+      def writable?(filename)
+        unix_mode_cmp(filename, 0o222)
       end
       alias writable_real? writable?
 
-      def executable?(fileName)
-        unix_mode_cmp(fileName, 0o111)
+      def executable?(filename)
+        unix_mode_cmp(filename, 0o111)
       end
       alias executable_real? executable?
 
-      def setuid?(fileName)
-        unix_mode_cmp(fileName, 0o4000)
+      def setuid?(filename)
+        unix_mode_cmp(filename, 0o4000)
       end
 
-      def setgid?(fileName)
-        unix_mode_cmp(fileName, 0o2000)
+      def setgid?(filename)
+        unix_mode_cmp(filename, 0o2000)
       end
 
-      def sticky?(fileName)
-        unix_mode_cmp(fileName, 0o1000)
+      def sticky?(filename)
+        unix_mode_cmp(filename, 0o1000)
       end
 
       def umask(*args)
         ::File.umask(*args)
       end
 
-      def truncate(_fileName, _len)
+      def truncate(_filename, _len)
         raise StandardError, 'truncate not supported'
       end
 
-      def directory?(fileName)
-        entry = @mappedZip.find_entry(fileName)
-        expand_path(fileName) == '/' || (!entry.nil? && entry.directory?)
+      def directory?(filename)
+        entry = @mapped_zip.find_entry(filename)
+        expand_path(filename) == '/' || (!entry.nil? && entry.directory?)
       end
 
-      def open(fileName, openMode = 'r', permissionInt = 0o644, &block)
-        openMode.delete!('b') # ignore b option
-        case openMode
+      def open(filename, mode = 'r', permissions = 0o644, &block)
+        mode.delete!('b') # ignore b option
+        case mode
         when 'r'
-          @mappedZip.get_input_stream(fileName, &block)
+          @mapped_zip.get_input_stream(filename, &block)
         when 'w'
-          @mappedZip.get_output_stream(fileName, permissionInt, &block)
+          @mapped_zip.get_output_stream(filename, permissions, &block)
         else
-          raise StandardError, "openmode '#{openMode} not supported" unless openMode == 'r'
+          raise StandardError, "openmode '#{mode} not supported" unless mode == 'r'
         end
       end
 
-      def new(fileName, openMode = 'r')
-        self.open(fileName, openMode)
+      def new(filename, mode = 'r')
+        self.open(filename, mode)
       end
 
-      def size(fileName)
-        @mappedZip.get_entry(fileName).size
+      def size(filename)
+        @mapped_zip.get_entry(filename).size
       end
 
       # Returns nil for not found and nil for directories
-      def size?(fileName)
-        entry = @mappedZip.find_entry(fileName)
+      def size?(filename)
+        entry = @mapped_zip.find_entry(filename)
         entry.nil? || entry.directory? ? nil : entry.size
       end
 
-      def chown(ownerInt, groupInt, *filenames)
+      def chown(owner, group, *filenames)
         filenames.each do |filename|
           e = get_entry(filename)
           e.extra.create('IUnix') unless e.extra.member?('IUnix')
-          e.extra['IUnix'].uid = ownerInt
-          e.extra['IUnix'].gid = groupInt
+          e.extra['IUnix'].uid = owner
+          e.extra['IUnix'].gid = group
         end
         filenames.size
       end
 
-      def chmod(modeInt, *filenames)
+      def chmod(mode, *filenames)
         filenames.each do |filename|
           e = get_entry(filename)
           e.fstype = 3 # force convertion filesystem type to unix
-          e.unix_perms = modeInt
-          e.external_file_attributes = modeInt << 16
+          e.unix_perms = mode
+          e.external_file_attributes = mode << 16
           e.dirty = true
         end
         filenames.size
       end
 
-      def zero?(fileName)
-        sz = size(fileName)
+      def zero?(filename)
+        sz = size(filename)
         sz.nil? || sz == 0
       rescue Errno::ENOENT
         false
       end
 
-      def file?(fileName)
-        entry = @mappedZip.find_entry(fileName)
+      def file?(filename)
+        entry = @mapped_zip.find_entry(filename)
         !entry.nil? && entry.file?
       end
 
-      def dirname(fileName)
-        ::File.dirname(fileName)
+      def dirname(filename)
+        ::File.dirname(filename)
       end
 
-      def basename(fileName)
-        ::File.basename(fileName)
+      def basename(filename)
+        ::File.basename(filename)
       end
 
-      def split(fileName)
-        ::File.split(fileName)
+      def split(filename)
+        ::File.split(filename)
       end
 
       def join(*fragments)
         ::File.join(*fragments)
       end
 
-      def utime(modifiedTime, *fileNames)
-        fileNames.each do |filename|
-          get_entry(filename).time = modifiedTime
+      def utime(modified_time, *filenames)
+        filenames.each do |filename|
+          get_entry(filename).time = modified_time
         end
       end
 
-      def mtime(fileName)
-        @mappedZip.get_entry(fileName).mtime
+      def mtime(filename)
+        @mapped_zip.get_entry(filename).mtime
       end
 
-      def atime(fileName)
-        e = get_entry(fileName)
+      def atime(filename)
+        e = get_entry(filename)
         if e.extra.member? 'UniversalTime'
           e.extra['UniversalTime'].atime
         elsif e.extra.member? 'NTFS'
@@ -332,8 +332,8 @@ module Zip
         end
       end
 
-      def ctime(fileName)
-        e = get_entry(fileName)
+      def ctime(filename)
+        e = get_entry(filename)
         if e.extra.member? 'UniversalTime'
           e.extra['UniversalTime'].ctime
         elsif e.extra.member? 'NTFS'
@@ -353,27 +353,27 @@ module Zip
         false
       end
 
-      def symlink?(_fileName)
+      def symlink?(_filename)
         false
       end
 
-      def socket?(_fileName)
+      def socket?(_filename)
         false
       end
 
-      def ftype(fileName)
-        @mappedZip.get_entry(fileName).directory? ? 'directory' : 'file'
+      def ftype(filename)
+        @mapped_zip.get_entry(filename).directory? ? 'directory' : 'file'
       end
 
-      def readlink(_fileName)
+      def readlink(_filename)
         raise NotImplementedError, 'The readlink() function is not implemented'
       end
 
-      def symlink(_fileName, _symlinkName)
+      def symlink(_filename, _symlink_name)
         raise NotImplementedError, 'The symlink() function is not implemented'
       end
 
-      def link(_fileName, _symlinkName)
+      def link(_filename, _symlink_name)
         raise NotImplementedError, 'The link() function is not implemented'
       end
 
@@ -381,28 +381,28 @@ module Zip
         raise NotImplementedError, 'The pipe() function is not implemented'
       end
 
-      def stat(fileName)
-        raise Errno::ENOENT, fileName unless exists?(fileName)
+      def stat(filename)
+        raise Errno::ENOENT, filename unless exists?(filename)
 
-        ZipFsStat.new(self, fileName)
+        ZipFsStat.new(self, filename)
       end
 
       alias lstat stat
 
-      def readlines(fileName)
-        self.open(fileName, &:readlines)
+      def readlines(filename)
+        self.open(filename, &:readlines)
       end
 
-      def read(fileName)
-        @mappedZip.read(fileName)
+      def read(filename)
+        @mapped_zip.read(filename)
       end
 
-      def popen(*args, &aProc)
-        ::File.popen(*args, &aProc)
+      def popen(*args, &a_proc)
+        ::File.popen(*args, &a_proc)
       end
 
-      def foreach(fileName, aSep = $INPUT_RECORD_SEPARATOR, &aProc)
-        self.open(fileName) { |is| is.each_line(aSep, &aProc) }
+      def foreach(filename, sep = $INPUT_RECORD_SEPARATOR, &a_proc)
+        self.open(filename) { |is| is.each_line(sep, &a_proc) }
       end
 
       def delete(*args)
@@ -411,18 +411,18 @@ module Zip
             raise Errno::EISDIR, "Is a directory - \"#{filename}\""
           end
 
-          @mappedZip.remove(filename)
+          @mapped_zip.remove(filename)
         end
       end
 
-      def rename(fileToRename, newName)
-        @mappedZip.rename(fileToRename, newName) { true }
+      def rename(file_to_rename, new_name)
+        @mapped_zip.rename(file_to_rename, new_name) { true }
       end
 
       alias unlink delete
 
-      def expand_path(aPath)
-        @mappedZip.expand_path(aPath)
+      def expand_path(path)
+        @mapped_zip.expand_path(path)
       end
     end
 
@@ -433,18 +433,18 @@ module Zip
     # The individual methods are not documented due to their
     # similarity with the methods in Dir
     class ZipFsDir
-      def initialize(mappedZip)
-        @mappedZip = mappedZip
+      def initialize(mapped_zip)
+        @mapped_zip = mapped_zip
       end
 
       attr_writer :file
 
-      def new(aDirectoryName)
-        ZipFsDirIterator.new(entries(aDirectoryName))
+      def new(directory_name)
+        ZipFsDirIterator.new(entries(directory_name))
       end
 
-      def open(aDirectoryName)
-        dirIt = new(aDirectoryName)
+      def open(directory_name)
+        dirIt = new(directory_name)
         if block_given?
           begin
             yield(dirIt)
@@ -457,55 +457,55 @@ module Zip
       end
 
       def pwd
-        @mappedZip.pwd
+        @mapped_zip.pwd
       end
       alias getwd pwd
 
-      def chdir(aDirectoryName)
-        unless @file.stat(aDirectoryName).directory?
-          raise Errno::EINVAL, "Invalid argument - #{aDirectoryName}"
+      def chdir(directory_name)
+        unless @file.stat(directory_name).directory?
+          raise Errno::EINVAL, "Invalid argument - #{directory_name}"
         end
 
-        @mappedZip.pwd = @file.expand_path(aDirectoryName)
+        @mapped_zip.pwd = @file.expand_path(directory_name)
       end
 
-      def entries(aDirectoryName)
+      def entries(directory_name)
         entries = []
-        foreach(aDirectoryName) { |e| entries << e }
+        foreach(directory_name) { |e| entries << e }
         entries
       end
 
       def glob(*args, &block)
-        @mappedZip.glob(*args, &block)
+        @mapped_zip.glob(*args, &block)
       end
 
-      def foreach(aDirectoryName)
-        unless @file.stat(aDirectoryName).directory?
-          raise Errno::ENOTDIR, aDirectoryName
+      def foreach(directory_name)
+        unless @file.stat(directory_name).directory?
+          raise Errno::ENOTDIR, directory_name
         end
 
-        path = @file.expand_path(aDirectoryName)
+        path = @file.expand_path(directory_name)
         path << '/' unless path.end_with?('/')
         path = Regexp.escape(path)
         subDirEntriesRegex = Regexp.new("^#{path}([^/]+)$")
-        @mappedZip.each do |filename|
+        @mapped_zip.each do |filename|
           match = subDirEntriesRegex.match(filename)
           yield(match[1]) unless match.nil?
         end
       end
 
-      def delete(entryName)
-        unless @file.stat(entryName).directory?
-          raise Errno::EINVAL, "Invalid argument - #{entryName}"
+      def delete(entry_name)
+        unless @file.stat(entry_name).directory?
+          raise Errno::EINVAL, "Invalid argument - #{entry_name}"
         end
 
-        @mappedZip.remove(entryName)
+        @mapped_zip.remove(entry_name)
       end
       alias rmdir delete
       alias unlink delete
 
-      def mkdir(entryName, permissionInt = 0o755)
-        @mappedZip.mkdir(entryName, permissionInt)
+      def mkdir(entry_name, permissions = 0o755)
+        @mapped_zip.mkdir(entry_name, permissions)
       end
 
       def chroot(*_args)
@@ -516,41 +516,41 @@ module Zip
     class ZipFsDirIterator # :nodoc:all
       include Enumerable
 
-      def initialize(arrayOfFileNames)
-        @fileNames = arrayOfFileNames
+      def initialize(filenames)
+        @filenames = filenames
         @index = 0
       end
 
       def close
-        @fileNames = nil
+        @filenames = nil
       end
 
-      def each(&aProc)
-        raise IOError, 'closed directory' if @fileNames.nil?
+      def each(&a_proc)
+        raise IOError, 'closed directory' if @filenames.nil?
 
-        @fileNames.each(&aProc)
+        @filenames.each(&a_proc)
       end
 
       def read
-        raise IOError, 'closed directory' if @fileNames.nil?
+        raise IOError, 'closed directory' if @filenames.nil?
 
-        @fileNames[(@index += 1) - 1]
+        @filenames[(@index += 1) - 1]
       end
 
       def rewind
-        raise IOError, 'closed directory' if @fileNames.nil?
+        raise IOError, 'closed directory' if @filenames.nil?
 
         @index = 0
       end
 
-      def seek(anIntegerPosition)
-        raise IOError, 'closed directory' if @fileNames.nil?
+      def seek(position)
+        raise IOError, 'closed directory' if @filenames.nil?
 
-        @index = anIntegerPosition
+        @index = position
       end
 
       def tell
-        raise IOError, 'closed directory' if @fileNames.nil?
+        raise IOError, 'closed directory' if @filenames.nil?
 
         @index
       end
@@ -561,60 +561,65 @@ module Zip
     class ZipFileNameMapper # :nodoc:all
       include Enumerable
 
-      def initialize(zipFile)
-        @zipFile = zipFile
+      def initialize(zip_file)
+        @zip_file = zip_file
         @pwd = '/'
       end
 
       attr_accessor :pwd
 
-      def find_entry(fileName)
-        @zipFile.find_entry(expand_to_entry(fileName))
+      def find_entry(filename)
+        @zip_file.find_entry(expand_to_entry(filename))
       end
 
-      def get_entry(fileName)
-        @zipFile.get_entry(expand_to_entry(fileName))
+      def get_entry(filename)
+        @zip_file.get_entry(expand_to_entry(filename))
       end
 
-      def get_input_stream(fileName, &aProc)
-        @zipFile.get_input_stream(expand_to_entry(fileName), &aProc)
+      def get_input_stream(filename, &a_proc)
+        @zip_file.get_input_stream(expand_to_entry(filename), &a_proc)
       end
 
-      def get_output_stream(fileName, permissionInt = nil, &aProc)
-        @zipFile.get_output_stream(expand_to_entry(fileName), permissionInt, &aProc)
+      def get_output_stream(filename, permissions = nil, &a_proc)
+        @zip_file.get_output_stream(
+          expand_to_entry(filename), permissions, &a_proc
+        )
       end
 
       def glob(pattern, *flags, &block)
-        @zipFile.glob(expand_to_entry(pattern), *flags, &block)
+        @zip_file.glob(expand_to_entry(pattern), *flags, &block)
       end
 
-      def read(fileName)
-        @zipFile.read(expand_to_entry(fileName))
+      def read(filename)
+        @zip_file.read(expand_to_entry(filename))
       end
 
-      def remove(fileName)
-        @zipFile.remove(expand_to_entry(fileName))
+      def remove(filename)
+        @zip_file.remove(expand_to_entry(filename))
       end
 
-      def rename(fileName, newName, &continueOnExistsProc)
-        @zipFile.rename(expand_to_entry(fileName), expand_to_entry(newName),
-                        &continueOnExistsProc)
+      def rename(filename, new_name, &continue_on_exists_proc)
+        @zip_file.rename(
+          expand_to_entry(filename),
+          expand_to_entry(new_name),
+          &continue_on_exists_proc
+        )
       end
 
-      def mkdir(fileName, permissionInt = 0o755)
-        @zipFile.mkdir(expand_to_entry(fileName), permissionInt)
+      def mkdir(filename, permissions = 0o755)
+        @zip_file.mkdir(expand_to_entry(filename), permissions)
       end
 
       # Turns entries into strings and adds leading /
       # and removes trailing slash on directories
       def each
-        @zipFile.each do |e|
+        @zip_file.each do |e|
           yield('/' + e.to_s.chomp('/'))
         end
       end
 
-      def expand_path(aPath)
-        expanded = aPath.start_with?('/') ? aPath : ::File.join(@pwd, aPath)
+      def expand_path(path)
+        expanded = path.start_with?('/') ? path : ::File.join(@pwd, path)
         expanded.gsub!(/\/\.(\/|$)/, '')
         expanded.gsub!(/[^\/]+\/\.\.(\/|$)/, '')
         expanded.empty? ? '/' : expanded
@@ -622,8 +627,8 @@ module Zip
 
       private
 
-      def expand_to_entry(aPath)
-        expand_path(aPath)[1..-1]
+      def expand_to_entry(path)
+        expand_path(path)[1..-1]
       end
     end
   end

--- a/lib/zip/pass_thru_compressor.rb
+++ b/lib/zip/pass_thru_compressor.rb
@@ -1,8 +1,8 @@
 module Zip
   class PassThruCompressor < Compressor #:nodoc:all
-    def initialize(outputStream)
+    def initialize(output_stream)
       super()
-      @output_stream = outputStream
+      @output_stream = output_stream
       @crc = Zlib.crc32
       @size = 0
     end

--- a/lib/zip/streamable_directory.rb
+++ b/lib/zip/streamable_directory.rb
@@ -1,11 +1,11 @@
 module Zip
   class StreamableDirectory < Entry
-    def initialize(zipfile, entry, srcPath = nil, permissionInt = nil)
+    def initialize(zipfile, entry, src_path = nil, permission = nil)
       super(zipfile, entry)
 
       @ftype = :directory
-      entry.get_extra_attributes_from_path(srcPath) if srcPath
-      @unix_perms = permissionInt if permissionInt
+      entry.get_extra_attributes_from_path(src_path) if src_path
+      @unix_perms = permission if permission
     end
   end
 end

--- a/lib/zip/streamable_stream.rb
+++ b/lib/zip/streamable_stream.rb
@@ -36,9 +36,9 @@ module Zip
       end
     end
 
-    def write_to_zip_output_stream(aZipOutputStream)
-      aZipOutputStream.put_next_entry(self)
-      get_input_stream { |is| ::Zip::IOExtras.copy_stream(aZipOutputStream, is) }
+    def write_to_zip_output_stream(output_stream)
+      output_stream.put_next_entry(self)
+      get_input_stream { |is| ::Zip::IOExtras.copy_stream(output_stream, is) }
     end
 
     def clean_up

--- a/samples/gtk_ruby_zip.rb
+++ b/samples/gtk_ruby_zip.rb
@@ -18,14 +18,14 @@ class MainApp < Gtk::Window
     add(box)
 
     @zipfile = nil
-    @buttonPanel = ButtonPanel.new
-    @buttonPanel.openButton.signal_connect(Gtk::Button::SIGNAL_CLICKED) do
+    @button_panel = ButtonPanel.new
+    @button_panel.open_button.signal_connect(Gtk::Button::SIGNAL_CLICKED) do
       show_file_selector
     end
-    @buttonPanel.extractButton.signal_connect(Gtk::Button::SIGNAL_CLICKED) do
+    @button_panel.extract_button.signal_connect(Gtk::Button::SIGNAL_CLICKED) do
       puts 'Not implemented!'
     end
-    box.pack_start(@buttonPanel, false, false, 0)
+    box.pack_start(@button_panel, false, false, 0)
 
     sw = Gtk::ScrolledWindow.new
     sw.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC)
@@ -42,27 +42,27 @@ class MainApp < Gtk::Window
   end
 
   class ButtonPanel < Gtk::HButtonBox
-    attr_reader :openButton, :extractButton
+    attr_reader :open_button, :extract_button
     def initialize
       super
       set_layout(Gtk::BUTTONBOX_START)
       set_spacing(0)
-      @openButton = Gtk::Button.new('Open archive')
-      @extractButton = Gtk::Button.new('Extract entry')
-      pack_start(@openButton)
-      pack_start(@extractButton)
+      @open_button = Gtk::Button.new('Open archive')
+      @extract_button = Gtk::Button.new('Extract entry')
+      pack_start(@open_button)
+      pack_start(@extract_button)
     end
   end
 
   def show_file_selector
-    @fileSelector = Gtk::FileSelection.new('Open zip file')
-    @fileSelector.show
-    @fileSelector.ok_button.signal_connect(Gtk::Button::SIGNAL_CLICKED) do
-      open_zip(@fileSelector.filename)
-      @fileSelector.destroy
+    @file_selector = Gtk::FileSelection.new('Open zip file')
+    @file_selector.show
+    @file_selector.ok_button.signal_connect(Gtk::Button::SIGNAL_CLICKED) do
+      open_zip(@file_selector.filename)
+      @file_selector.destroy
     end
-    @fileSelector.cancel_button.signal_connect(Gtk::Button::SIGNAL_CLICKED) do
-      @fileSelector.destroy
+    @file_selector.cancel_button.signal_connect(Gtk::Button::SIGNAL_CLICKED) do
+      @file_selector.destroy
     end
   end
 
@@ -77,8 +77,8 @@ class MainApp < Gtk::Window
   end
 end
 
-mainApp = MainApp.new
+main_app = MainApp.new
 
-mainApp.show_all
+main_app.show_all
 
 Gtk.main

--- a/samples/qtzip.rb
+++ b/samples/qtzip.rb
@@ -20,12 +20,12 @@ class ZipDialog < ZipDialogUI
             self, SLOT('extract_files()'))
   end
 
-  def zipfile(&proc)
-    Zip::File.open(@zip_filename, &proc)
+  def zipfile(&a_proc)
+    Zip::File.open(@zip_filename, &a_proc)
   end
 
-  def each(&proc)
-    Zip::File.foreach(@zip_filename, &proc)
+  def each(&a_proc)
+    Zip::File.foreach(@zip_filename, &a_proc)
   end
 
   def refresh

--- a/samples/zipfind.rb
+++ b/samples/zipfind.rb
@@ -9,10 +9,10 @@ require 'find'
 
 module Zip
   module ZipFind
-    def self.find(path, zipFilePattern = /\.zip$/i)
+    def self.find(path, zip_file_pattern = /\.zip$/i)
       Find.find(path) do |filename|
         yield(filename)
-        next unless zipFilePattern.match(filename) && File.file?(filename)
+        next unless zip_file_pattern.match(filename) && File.file?(filename)
 
         begin
           Zip::File.foreach(filename) do |entry|
@@ -24,9 +24,9 @@ module Zip
       end
     end
 
-    def self.find_file(path, fileNamePattern, zipFilePattern = /\.zip$/i)
-      find(path, zipFilePattern) do |filename|
-        yield(filename) if fileNamePattern.match(filename)
+    def self.find_file(path, filename_pattern, zip_file_pattern = /\.zip$/i)
+      find(path, zip_file_pattern) do |filename|
+        yield(filename) if filename_pattern.match(filename)
       end
     end
   end
@@ -58,8 +58,8 @@ if $PROGRAM_NAME == __FILE__
       puts "Usage: #{$PROGRAM_NAME} PATH ZIPFILENAME_PATTERN FILNAME_PATTERN"
     end
 
-    def self.report_entry_found(fileName)
-      puts fileName
+    def self.report_entry_found(filename)
+      puts filename
     end
   end
 

--- a/samples/zipfind.rb
+++ b/samples/zipfind.rb
@@ -10,13 +10,13 @@ require 'find'
 module Zip
   module ZipFind
     def self.find(path, zipFilePattern = /\.zip$/i)
-      Find.find(path) do |fileName|
-        yield(fileName)
-        next unless zipFilePattern.match(fileName) && File.file?(fileName)
+      Find.find(path) do |filename|
+        yield(filename)
+        next unless zipFilePattern.match(filename) && File.file?(filename)
 
         begin
-          Zip::File.foreach(fileName) do |zipEntry|
-            yield(fileName + File::SEPARATOR + zipEntry.to_s)
+          Zip::File.foreach(filename) do |entry|
+            yield(filename + File::SEPARATOR + entry.to_s)
           end
         rescue Errno::EACCES => e
           puts e
@@ -25,8 +25,8 @@ module Zip
     end
 
     def self.find_file(path, fileNamePattern, zipFilePattern = /\.zip$/i)
-      find(path, zipFilePattern) do |fileName|
-        yield(fileName) if fileNamePattern.match(fileName)
+      find(path, zipFilePattern) do |filename|
+        yield(filename) if fileNamePattern.match(filename)
       end
     end
   end
@@ -42,8 +42,8 @@ if $PROGRAM_NAME == __FILE__
       check_args(args)
       Zip::ZipFind.find_file(args[PATH_ARG_INDEX],
                              args[FILENAME_PATTERN_ARG_INDEX],
-                             args[ZIPFILE_PATTERN_ARG_INDEX]) do |fileName|
-        report_entry_found fileName
+                             args[ZIPFILE_PATTERN_ARG_INDEX]) do |filename|
+        report_entry_found filename
       end
     end
 

--- a/test/basic_zip_file_test.rb
+++ b/test/basic_zip_file_test.rb
@@ -5,7 +5,6 @@ class BasicZipFileTest < MiniTest::Test
 
   def setup
     @zip_file = ::Zip::File.new(TestZipFile::TEST_ZIP2.zip_name)
-    @testEntryNameIndex = 0
   end
 
   def test_entries
@@ -50,11 +49,9 @@ class BasicZipFileTest < MiniTest::Test
   end
 
   def test_get_input_stream_block
-    fileAndEntryName = @zip_file.entries.first.name
-    @zip_file.get_input_stream(fileAndEntryName) do |zis|
-      assert_entry_contents_for_stream(fileAndEntryName,
-                                       zis,
-                                       fileAndEntryName)
+    name = @zip_file.entries.first.name
+    @zip_file.get_input_stream(name) do |zis|
+      assert_entry_contents_for_stream(name, zis, name)
     end
   end
 end

--- a/test/case_sensitivity_test.rb
+++ b/test/case_sensitivity_test.rb
@@ -63,8 +63,11 @@ class ZipCaseSensitivityTest < MiniTest::Test
 
   private
 
-  def assert_contains(zf, entryName, filename = entryName)
-    refute_nil(zf.entries.detect { |e| e.name == entryName }, "entry #{entryName} not in #{zf.entries.join(', ')} in zip file #{zf}")
-    assert_entry_contents(zf, entryName, filename) if File.exist?(filename)
+  def assert_contains(zip_file, entry_name, filename = entry_name)
+    refute_nil(
+      zip_file.entries.detect { |e| e.name == entry_name },
+      "entry #{entry_name} not in #{zip_file.entries.join(', ')} in zip file #{zip_file}"
+    )
+    assert_entry_contents(zip_file, entry_name, filename) if File.exist?(filename)
   end
 end

--- a/test/case_sensitivity_test.rb
+++ b/test/case_sensitivity_test.rb
@@ -20,12 +20,12 @@ class ZipCaseSensitivityTest < MiniTest::Test
     SRC_FILES.each { |fn, en| zf.add(en, fn) }
     zf.close
 
-    zfRead = ::Zip::File.new(EMPTY_FILENAME)
-    assert_equal(SRC_FILES.size, zfRead.entries.length)
+    zf_read = ::Zip::File.new(EMPTY_FILENAME)
+    assert_equal(SRC_FILES.size, zf_read.entries.length)
     SRC_FILES.each_with_index do |a, i|
-      assert_equal(a.last, zfRead.entries[i].name)
+      assert_equal(a.last, zf_read.entries[i].name)
       AssertEntry.assert_contents(a.first,
-                                  zfRead.get_input_stream(a.last, &:read))
+                                  zf_read.get_input_stream(a.last, &:read))
     end
   end
 
@@ -53,11 +53,11 @@ class ZipCaseSensitivityTest < MiniTest::Test
 
     ::Zip.case_insensitive_match = true
 
-    zfRead = ::Zip::File.new(EMPTY_FILENAME)
-    assert_equal(SRC_FILES.collect { |_fn, en| en.downcase }.uniq.size, zfRead.entries.length)
-    assert_equal(SRC_FILES.last.last.downcase, zfRead.entries.first.name.downcase)
+    zf_read = ::Zip::File.new(EMPTY_FILENAME)
+    assert_equal(SRC_FILES.collect { |_fn, en| en.downcase }.uniq.size, zf_read.entries.length)
+    assert_equal(SRC_FILES.last.last.downcase, zf_read.entries.first.name.downcase)
     AssertEntry.assert_contents(
-      SRC_FILES.last.first, zfRead.get_input_stream(SRC_FILES.last.last, &:read)
+      SRC_FILES.last.first, zf_read.get_input_stream(SRC_FILES.last.last, &:read)
     )
   end
 

--- a/test/central_directory_test.rb
+++ b/test/central_directory_test.rb
@@ -6,21 +6,21 @@ class ZipCentralDirectoryTest < MiniTest::Test
   end
 
   def test_read_from_stream
-    ::File.open(TestZipFile::TEST_ZIP2.zip_name, 'rb') do |zipFile|
-      cdir = ::Zip::CentralDirectory.read_from_stream(zipFile)
+    ::File.open(TestZipFile::TEST_ZIP2.zip_name, 'rb') do |zip_file|
+      cdir = ::Zip::CentralDirectory.read_from_stream(zip_file)
 
       assert_equal(TestZipFile::TEST_ZIP2.entry_names.size, cdir.size)
-      assert(cdir.entries.sort.compare_enumerables(TestZipFile::TEST_ZIP2.entry_names.sort) do |cdirEntry, testEntryName|
-        cdirEntry.name == testEntryName
+      assert(cdir.entries.sort.compare_enumerables(TestZipFile::TEST_ZIP2.entry_names.sort) do |cdir_entry, test_entry_name|
+        cdir_entry.name == test_entry_name
       end)
       assert_equal(TestZipFile::TEST_ZIP2.comment, cdir.comment)
     end
   end
 
   def test_read_from_invalid_stream
-    File.open('test/data/file2.txt', 'rb') do |zipFile|
+    File.open('test/data/file2.txt', 'rb') do |zip_file|
       cdir = ::Zip::CentralDirectory.new
-      cdir.read_from_stream(zipFile)
+      cdir.read_from_stream(zip_file)
     end
     raise 'ZipError expected!'
   rescue ::Zip::Error

--- a/test/central_directory_test.rb
+++ b/test/central_directory_test.rb
@@ -41,12 +41,18 @@ class ZipCentralDirectoryTest < MiniTest::Test
     entries = [::Zip::Entry.new('file.zip', 'flimse', 'myComment', 'somethingExtra'),
                ::Zip::Entry.new('file.zip', 'secondEntryName'),
                ::Zip::Entry.new('file.zip', 'lastEntry.txt', 'Has a comment too')]
-    cdir = ::Zip::CentralDirectory.new(entries, 'my zip comment')
-    File.open('test/data/generated/cdirtest.bin', 'wb') { |f| cdir.write_to_stream(f) }
-    cdirReadback = ::Zip::CentralDirectory.new
-    File.open('test/data/generated/cdirtest.bin', 'rb') { |f| cdirReadback.read_from_stream(f) }
 
-    assert_equal(cdir.entries.sort, cdirReadback.entries.sort)
+    cdir = ::Zip::CentralDirectory.new(entries, 'my zip comment')
+    File.open('test/data/generated/cdirtest.bin', 'wb') do |f|
+      cdir.write_to_stream(f)
+    end
+
+    cdir_readback = ::Zip::CentralDirectory.new
+    File.open('test/data/generated/cdirtest.bin', 'rb') do |f|
+      cdir_readback.read_from_stream(f)
+    end
+
+    assert_equal(cdir.entries.sort, cdir_readback.entries.sort)
   end
 
   def test_write64_to_stream
@@ -58,13 +64,19 @@ class ZipCentralDirectoryTest < MiniTest::Test
     [0, 250, 18_000_000_300, 33_000_000_350].each_with_index do |offset, index|
       entries[index].local_header_offset = offset
     end
-    cdir = ::Zip::CentralDirectory.new(entries, 'zip comment')
-    File.open('test/data/generated/cdir64test.bin', 'wb') { |f| cdir.write_to_stream(f) }
-    cdirReadback = ::Zip::CentralDirectory.new
-    File.open('test/data/generated/cdir64test.bin', 'rb') { |f| cdirReadback.read_from_stream(f) }
 
-    assert_equal(cdir.entries.sort, cdirReadback.entries.sort)
-    assert_equal(::Zip::VERSION_NEEDED_TO_EXTRACT_ZIP64, cdirReadback.instance_variable_get(:@version_needed_for_extract))
+    cdir = ::Zip::CentralDirectory.new(entries, 'zip comment')
+    File.open('test/data/generated/cdir64test.bin', 'wb') do |f|
+      cdir.write_to_stream(f)
+    end
+
+    cdir_readback = ::Zip::CentralDirectory.new
+    File.open('test/data/generated/cdir64test.bin', 'rb') do |f|
+      cdir_readback.read_from_stream(f)
+    end
+
+    assert_equal(cdir.entries.sort, cdir_readback.entries.sort)
+    assert_equal(::Zip::VERSION_NEEDED_TO_EXTRACT_ZIP64, cdir_readback.instance_variable_get(:@version_needed_for_extract))
   end
 
   def test_equality

--- a/test/deflater_test.rb
+++ b/test/deflater_test.rb
@@ -11,8 +11,8 @@ class DeflaterTest < MiniTest::Test
   def test_output_operator
     txt = load_file('test/data/file2.txt')
     deflate(txt, DEFLATER_TEST_FILE)
-    inflatedTxt = inflate(DEFLATER_TEST_FILE)
-    assert_equal(txt, inflatedTxt)
+    inflated_txt = inflate(DEFLATER_TEST_FILE)
+    assert_equal(txt, inflated_txt)
   end
 
   def test_default_compression

--- a/test/deflater_test.rb
+++ b/test/deflater_test.rb
@@ -42,12 +42,12 @@ class DeflaterTest < MiniTest::Test
 
   private
 
-  def load_file(fileName)
-    File.open(fileName, 'rb', &:read)
+  def load_file(filename)
+    File.open(filename, 'rb', &:read)
   end
 
-  def deflate(data, fileName)
-    File.open(fileName, 'wb') do |file|
+  def deflate(data, filename)
+    File.open(filename, 'wb') do |file|
       deflater = ::Zip::Deflater.new(file)
       deflater << data
       deflater.finish
@@ -56,8 +56,8 @@ class DeflaterTest < MiniTest::Test
     end
   end
 
-  def inflate(fileName)
-    File.open(fileName, 'rb') do |file|
+  def inflate(filename)
+    File.open(filename, 'rb') do |file|
       inflater = ::Zip::Inflater.new(file)
       inflater.read
     end

--- a/test/entry_set_test.rb
+++ b/test/entry_set_test.rb
@@ -11,7 +11,7 @@ class ZipEntrySetTest < MiniTest::Test
   ]
 
   def setup
-    @zipEntrySet = ::Zip::EntrySet.new(ZIP_ENTRIES)
+    @zip_entry_set = ::Zip::EntrySet.new(ZIP_ENTRIES)
   end
 
   def teardown
@@ -19,15 +19,15 @@ class ZipEntrySetTest < MiniTest::Test
   end
 
   def test_include
-    assert(@zipEntrySet.include?(ZIP_ENTRIES.first))
-    assert(!@zipEntrySet.include?(::Zip::Entry.new('different.zip', 'different', 'aComment')))
+    assert(@zip_entry_set.include?(ZIP_ENTRIES.first))
+    assert(!@zip_entry_set.include?(::Zip::Entry.new('different.zip', 'different', 'aComment')))
   end
 
   def test_size
-    assert_equal(ZIP_ENTRIES.size, @zipEntrySet.size)
-    assert_equal(ZIP_ENTRIES.size, @zipEntrySet.length)
-    @zipEntrySet << ::Zip::Entry.new('a', 'b', 'c')
-    assert_equal(ZIP_ENTRIES.size + 1, @zipEntrySet.length)
+    assert_equal(ZIP_ENTRIES.size, @zip_entry_set.size)
+    assert_equal(ZIP_ENTRIES.size, @zip_entry_set.length)
+    @zip_entry_set << ::Zip::Entry.new('a', 'b', 'c')
+    assert_equal(ZIP_ENTRIES.size + 1, @zip_entry_set.length)
   end
 
   def test_add
@@ -41,20 +41,20 @@ class ZipEntrySetTest < MiniTest::Test
   end
 
   def test_delete
-    assert_equal(ZIP_ENTRIES.size, @zipEntrySet.size)
-    entry = @zipEntrySet.delete(ZIP_ENTRIES.first)
-    assert_equal(ZIP_ENTRIES.size - 1, @zipEntrySet.size)
+    assert_equal(ZIP_ENTRIES.size, @zip_entry_set.size)
+    entry = @zip_entry_set.delete(ZIP_ENTRIES.first)
+    assert_equal(ZIP_ENTRIES.size - 1, @zip_entry_set.size)
     assert_equal(ZIP_ENTRIES.first, entry)
 
-    entry = @zipEntrySet.delete(ZIP_ENTRIES.first)
-    assert_equal(ZIP_ENTRIES.size - 1, @zipEntrySet.size)
+    entry = @zip_entry_set.delete(ZIP_ENTRIES.first)
+    assert_equal(ZIP_ENTRIES.size - 1, @zip_entry_set.size)
     assert_nil(entry)
   end
 
   def test_each
     # Used each instead each_with_index due the bug in jRuby
     count = 0
-    @zipEntrySet.each do |entry|
+    @zip_entry_set.each do |entry|
       assert(ZIP_ENTRIES.include?(entry))
       count += 1
     end
@@ -62,57 +62,57 @@ class ZipEntrySetTest < MiniTest::Test
   end
 
   def test_entries
-    assert_equal(ZIP_ENTRIES, @zipEntrySet.entries)
+    assert_equal(ZIP_ENTRIES, @zip_entry_set.entries)
   end
 
   def test_find_entry
     entries = [::Zip::Entry.new('zipfile.zip', 'MiXeDcAsEnAmE', 'comment1')]
 
     ::Zip.case_insensitive_match = true
-    zipEntrySet = ::Zip::EntrySet.new(entries)
-    assert_equal(entries[0], zipEntrySet.find_entry('MiXeDcAsEnAmE'))
-    assert_equal(entries[0], zipEntrySet.find_entry('mixedcasename'))
+    zip_entry_set = ::Zip::EntrySet.new(entries)
+    assert_equal(entries[0], zip_entry_set.find_entry('MiXeDcAsEnAmE'))
+    assert_equal(entries[0], zip_entry_set.find_entry('mixedcasename'))
 
     ::Zip.case_insensitive_match = false
-    zipEntrySet = ::Zip::EntrySet.new(entries)
-    assert_equal(entries[0], zipEntrySet.find_entry('MiXeDcAsEnAmE'))
-    assert_nil(zipEntrySet.find_entry('mixedcasename'))
+    zip_entry_set = ::Zip::EntrySet.new(entries)
+    assert_equal(entries[0], zip_entry_set.find_entry('MiXeDcAsEnAmE'))
+    assert_nil(zip_entry_set.find_entry('mixedcasename'))
   end
 
   def test_entries_with_sort
     ::Zip.sort_entries = true
-    assert_equal(ZIP_ENTRIES.sort, @zipEntrySet.entries)
+    assert_equal(ZIP_ENTRIES.sort, @zip_entry_set.entries)
     ::Zip.sort_entries = false
-    assert_equal(ZIP_ENTRIES, @zipEntrySet.entries)
+    assert_equal(ZIP_ENTRIES, @zip_entry_set.entries)
   end
 
   def test_entries_sorted_in_each
     ::Zip.sort_entries = true
     arr = []
-    @zipEntrySet.each do |entry|
+    @zip_entry_set.each do |entry|
       arr << entry
     end
     assert_equal(ZIP_ENTRIES.sort, arr)
   end
 
   def test_compound
-    newEntry = ::Zip::Entry.new('zf.zip', 'new entry', "new entry's comment")
-    assert_equal(ZIP_ENTRIES.size, @zipEntrySet.size)
-    @zipEntrySet << newEntry
-    assert_equal(ZIP_ENTRIES.size + 1, @zipEntrySet.size)
-    assert(@zipEntrySet.include?(newEntry))
+    new_entry = ::Zip::Entry.new('zf.zip', 'new entry', "new entry's comment")
+    assert_equal(ZIP_ENTRIES.size, @zip_entry_set.size)
+    @zip_entry_set << new_entry
+    assert_equal(ZIP_ENTRIES.size + 1, @zip_entry_set.size)
+    assert(@zip_entry_set.include?(new_entry))
 
-    @zipEntrySet.delete(newEntry)
-    assert_equal(ZIP_ENTRIES.size, @zipEntrySet.size)
+    @zip_entry_set.delete(new_entry)
+    assert_equal(ZIP_ENTRIES.size, @zip_entry_set.size)
   end
 
   def test_dup
-    copy = @zipEntrySet.dup
-    assert_equal(@zipEntrySet, copy)
+    copy = @zip_entry_set.dup
+    assert_equal(@zip_entry_set, copy)
 
     # demonstrate that this is a deep copy
     copy.entries[0].name = 'a totally different name'
-    assert(@zipEntrySet != copy)
+    assert(@zip_entry_set != copy)
   end
 
   def test_parent
@@ -121,15 +121,15 @@ class ZipEntrySetTest < MiniTest::Test
       ::Zip::Entry.new('zf.zip', 'a/b/'),
       ::Zip::Entry.new('zf.zip', 'a/b/c/')
     ]
-    entrySet = ::Zip::EntrySet.new(entries)
+    entry_set = ::Zip::EntrySet.new(entries)
 
-    assert_nil(entrySet.parent(entries[0]))
-    assert_equal(entries[0], entrySet.parent(entries[1]))
-    assert_equal(entries[1], entrySet.parent(entries[2]))
+    assert_nil(entry_set.parent(entries[0]))
+    assert_equal(entries[0], entry_set.parent(entries[1]))
+    assert_equal(entries[1], entry_set.parent(entries[2]))
   end
 
   def test_glob
-    res = @zipEntrySet.glob('name[2-4]')
+    res = @zip_entry_set.glob('name[2-4]')
     assert_equal(3, res.size)
     assert_equal(ZIP_ENTRIES[1, 3].sort, res.sort)
   end
@@ -141,13 +141,13 @@ class ZipEntrySetTest < MiniTest::Test
       ::Zip::Entry.new('zf.zip', 'a/b/c/'),
       ::Zip::Entry.new('zf.zip', 'a/b/c/c1')
     ]
-    entrySet = ::Zip::EntrySet.new(entries)
+    entry_set = ::Zip::EntrySet.new(entries)
 
-    assert_equal(entries[0, 1], entrySet.glob('*'))
-    # assert_equal(entries[FIXME], entrySet.glob("**"))
-    # res = entrySet.glob('a*')
+    assert_equal(entries[0, 1], entry_set.glob('*'))
+    # assert_equal(entries[FIXME], entry_set.glob("**"))
+    # res = entry_set.glob('a*')
     # assert_equal(entries.size, res.size)
-    # assert_equal(entrySet.map { |e| e.name }, res.map { |e| e.name })
+    # assert_equal(entry_set.map { |e| e.name }, res.map { |e| e.name })
   end
 
   def test_glob3
@@ -156,8 +156,8 @@ class ZipEntrySetTest < MiniTest::Test
       ::Zip::Entry.new('zf.zip', 'a/b'),
       ::Zip::Entry.new('zf.zip', 'a/c')
     ]
-    entrySet = ::Zip::EntrySet.new(entries)
+    entry_set = ::Zip::EntrySet.new(entries)
 
-    assert_equal(entries[0, 2].sort, entrySet.glob('a/{a,b}').sort)
+    assert_equal(entries[0, 2].sort, entry_set.glob('a/{a,b}').sort)
   end
 end

--- a/test/file_extract_directory_test.rb
+++ b/test/file_extract_directory_test.rb
@@ -41,14 +41,14 @@ class ZipFileExtractDirectoryTest < MiniTest::Test
 
   def test_extract_directory_exists_as_file_overwrite
     File.open(TEST_OUT_NAME, 'w') { |f| f.puts 'something' }
-    gotCalled = false
+    called = false
     extract_test_dir do |entry, dest_path|
-      gotCalled = true
+      called = true
       assert_equal(TEST_OUT_NAME, dest_path)
       assert(entry.directory?)
       true
     end
-    assert(gotCalled)
+    assert(called)
     assert(File.directory?(TEST_OUT_NAME))
   end
 end

--- a/test/file_extract_directory_test.rb
+++ b/test/file_extract_directory_test.rb
@@ -5,14 +5,14 @@ class ZipFileExtractDirectoryTest < MiniTest::Test
 
   TEST_OUT_NAME = 'test/data/generated/emptyOutDir'
 
-  def open_zip(&aProc)
-    assert(!aProc.nil?)
-    ::Zip::File.open(TestZipFile::TEST_ZIP4.zip_name, &aProc)
+  def open_zip(&a_proc)
+    assert(!a_proc.nil?)
+    ::Zip::File.open(TestZipFile::TEST_ZIP4.zip_name, &a_proc)
   end
 
-  def extract_test_dir(&aProc)
+  def extract_test_dir(&a_proc)
     open_zip do |zf|
-      zf.extract(TestFiles::EMPTY_TEST_DIR, TEST_OUT_NAME, &aProc)
+      zf.extract(TestFiles::EMPTY_TEST_DIR, TEST_OUT_NAME, &a_proc)
     end
   end
 

--- a/test/file_extract_directory_test.rb
+++ b/test/file_extract_directory_test.rb
@@ -42,9 +42,9 @@ class ZipFileExtractDirectoryTest < MiniTest::Test
   def test_extract_directory_exists_as_file_overwrite
     File.open(TEST_OUT_NAME, 'w') { |f| f.puts 'something' }
     gotCalled = false
-    extract_test_dir do |entry, destPath|
+    extract_test_dir do |entry, dest_path|
       gotCalled = true
-      assert_equal(TEST_OUT_NAME, destPath)
+      assert_equal(TEST_OUT_NAME, dest_path)
       assert(entry.directory?)
       true
     end

--- a/test/file_extract_test.rb
+++ b/test/file_extract_test.rb
@@ -34,8 +34,8 @@ class ZipFileExtractTest < MiniTest::Test
   end
 
   def test_extract_exists
-    writtenText = 'written text'
-    ::File.open(EXTRACTED_FILENAME, 'w') { |f| f.write(writtenText) }
+    text = 'written text'
+    ::File.open(EXTRACTED_FILENAME, 'w') { |f| f.write(text) }
 
     assert_raises(::Zip::DestinationFileExistsError) do
       ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
@@ -43,26 +43,26 @@ class ZipFileExtractTest < MiniTest::Test
       end
     end
     File.open(EXTRACTED_FILENAME, 'r') do |f|
-      assert_equal(writtenText, f.read)
+      assert_equal(text, f.read)
     end
   end
 
   def test_extract_exists_overwrite
-    writtenText = 'written text'
-    ::File.open(EXTRACTED_FILENAME, 'w') { |f| f.write(writtenText) }
+    text = 'written text'
+    ::File.open(EXTRACTED_FILENAME, 'w') { |f| f.write(text) }
 
-    gotCalledCorrectly = false
+    called_correctly = false
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
       zf.extract(zf.entries.first, EXTRACTED_FILENAME) do |entry, extract_loc|
-        gotCalledCorrectly = zf.entries.first == entry &&
-                             extract_loc == EXTRACTED_FILENAME
+        called_correctly = zf.entries.first == entry &&
+                           extract_loc == EXTRACTED_FILENAME
         true
       end
     end
 
-    assert(gotCalledCorrectly)
+    assert(called_correctly)
     ::File.open(EXTRACTED_FILENAME, 'r') do |f|
-      assert(writtenText != f.read)
+      assert(text != f.read)
     end
   end
 
@@ -74,15 +74,15 @@ class ZipFileExtractTest < MiniTest::Test
   end
 
   def test_extract_non_entry_2
-    outFile = 'outfile'
+    out_file = 'outfile'
     assert_raises(Errno::ENOENT) do
       zf = ::Zip::File.new(TEST_ZIP.zip_name)
-      nonEntry = 'hotdog-diddelidoo'
-      assert(!zf.entries.include?(nonEntry))
-      zf.extract(nonEntry, outFile)
+      non_entry = 'hotdog-diddelidoo'
+      assert(!zf.entries.include?(non_entry))
+      zf.extract(non_entry, out_file)
       zf.close
     end
-    assert(!File.exist?(outFile))
+    assert(!File.exist?(out_file))
   end
 
   def test_extract_incorrect_size

--- a/test/file_extract_test.rb
+++ b/test/file_extract_test.rb
@@ -53,9 +53,9 @@ class ZipFileExtractTest < MiniTest::Test
 
     gotCalledCorrectly = false
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      zf.extract(zf.entries.first, EXTRACTED_FILENAME) do |entry, extractLoc|
+      zf.extract(zf.entries.first, EXTRACTED_FILENAME) do |entry, extract_loc|
         gotCalledCorrectly = zf.entries.first == entry &&
-                             extractLoc == EXTRACTED_FILENAME
+                             extract_loc == EXTRACTED_FILENAME
         true
       end
     end

--- a/test/file_permissions_test.rb
+++ b/test/file_permissions_test.rb
@@ -15,7 +15,7 @@ class FilePermissionsTest < MiniTest::Test
   end
 
   def test_umask_000
-    set_umask(0o000) do
+    apply_umask(0o000) do
       create_files
     end
 
@@ -23,7 +23,7 @@ class FilePermissionsTest < MiniTest::Test
   end
 
   def test_umask_066
-    set_umask(0o066) do
+    apply_umask(0o066) do
       create_files
     end
 
@@ -31,7 +31,7 @@ class FilePermissionsTest < MiniTest::Test
   end
 
   def test_umask_027
-    set_umask(0o027) do
+    apply_umask(0o027) do
       create_files
     end
 
@@ -56,7 +56,7 @@ class FilePermissionsTest < MiniTest::Test
   end
 
   # If anything goes wrong, make sure the umask is restored.
-  def set_umask(umask)
+  def apply_umask(umask)
     saved_umask = ::File.umask(umask)
     yield
   ensure

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -22,9 +22,9 @@ class ZipFileTest < MiniTest::Test
 
     ::File.open(EMPTY_FILENAME, 'wb') { |file| file.write buffer.string }
 
-    zfRead = ::Zip::File.new(EMPTY_FILENAME)
-    assert_equal(comment, zfRead.comment)
-    assert_equal(2, zfRead.entries.length)
+    zf_read = ::Zip::File.new(EMPTY_FILENAME)
+    assert_equal(comment, zf_read.comment)
+    assert_equal(2, zf_read.entries.length)
   end
 
   def test_create_from_scratch
@@ -36,9 +36,9 @@ class ZipFileTest < MiniTest::Test
     zf.comment = comment
     zf.close
 
-    zfRead = ::Zip::File.new(EMPTY_FILENAME)
-    assert_equal(comment, zfRead.comment)
-    assert_equal(2, zfRead.entries.length)
+    zf_read = ::Zip::File.new(EMPTY_FILENAME)
+    assert_equal(comment, zf_read.comment)
+    assert_equal(2, zf_read.entries.length)
   end
 
   def test_create_from_scratch_with_old_create_parameter
@@ -50,9 +50,9 @@ class ZipFileTest < MiniTest::Test
     zf.comment = comment
     zf.close
 
-    zfRead = ::Zip::File.new(EMPTY_FILENAME)
-    assert_equal(comment, zfRead.comment)
-    assert_equal(2, zfRead.entries.length)
+    zf_read = ::Zip::File.new(EMPTY_FILENAME)
+    assert_equal(comment, zf_read.comment)
+    assert_equal(2, zf_read.entries.length)
   end
 
   def test_get_input_stream_stored_with_gpflag_bit3
@@ -62,26 +62,26 @@ class ZipFileTest < MiniTest::Test
   end
 
   def test_get_output_stream
-    entryCount = nil
+    count = nil
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      entryCount = zf.size
-      zf.get_output_stream('newEntry.txt') do |os|
-        os.write 'Putting stuff in newEntry.txt'
+      count = zf.size
+      zf.get_output_stream('new_entry.txt') do |os|
+        os.write 'Putting stuff in new_entry.txt'
       end
-      assert_equal(entryCount + 1, zf.size)
-      assert_equal('Putting stuff in newEntry.txt', zf.read('newEntry.txt'))
+      assert_equal(count + 1, zf.size)
+      assert_equal('Putting stuff in new_entry.txt', zf.read('new_entry.txt'))
 
       zf.get_output_stream(zf.get_entry('test/data/generated/empty.txt')) do |os|
         os.write 'Putting stuff in data/generated/empty.txt'
       end
-      assert_equal(entryCount + 1, zf.size)
+      assert_equal(count + 1, zf.size)
       assert_equal('Putting stuff in data/generated/empty.txt', zf.read('test/data/generated/empty.txt'))
 
       custom_entry_args = [TEST_COMMENT, TEST_EXTRA, TEST_COMPRESSED_SIZE, TEST_CRC, ::Zip::Entry::STORED, TEST_SIZE, TEST_TIME]
       zf.get_output_stream('entry_with_custom_args.txt', nil, *custom_entry_args) do |os|
         os.write 'Some data'
       end
-      assert_equal(entryCount + 2, zf.size)
+      assert_equal(count + 2, zf.size)
       entry = zf.get_entry('entry_with_custom_args.txt')
       assert_equal(custom_entry_args[0], entry.comment)
       assert_equal(custom_entry_args[2], entry.compressed_size)
@@ -96,8 +96,8 @@ class ZipFileTest < MiniTest::Test
     end
 
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      assert_equal(entryCount + 3, zf.size)
-      assert_equal('Putting stuff in newEntry.txt', zf.read('newEntry.txt'))
+      assert_equal(count + 3, zf.size)
+      assert_equal('Putting stuff in new_entry.txt', zf.read('new_entry.txt'))
       assert_equal('Putting stuff in data/generated/empty.txt', zf.read('test/data/generated/empty.txt'))
       assert_equal(File.open('test/data/generated/5entry.zip', 'rb').read, zf.read('entry.bin'))
     end
@@ -189,52 +189,52 @@ class ZipFileTest < MiniTest::Test
   end
 
   def test_add
-    srcFile = 'test/data/file2.txt'
-    entryName = 'newEntryName.rb'
-    assert(::File.exist?(srcFile))
+    src_file = 'test/data/file2.txt'
+    entry_name = 'newEntryName.rb'
+    assert(::File.exist?(src_file))
     zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
-    zf.add(entryName, srcFile)
+    zf.add(entry_name, src_file)
     zf.close
 
-    zfRead = ::Zip::File.new(EMPTY_FILENAME)
-    assert_equal('', zfRead.comment)
-    assert_equal(1, zfRead.entries.length)
-    assert_equal(entryName, zfRead.entries.first.name)
-    AssertEntry.assert_contents(srcFile,
-                                zfRead.get_input_stream(entryName, &:read))
+    zf_read = ::Zip::File.new(EMPTY_FILENAME)
+    assert_equal('', zf_read.comment)
+    assert_equal(1, zf_read.entries.length)
+    assert_equal(entry_name, zf_read.entries.first.name)
+    AssertEntry.assert_contents(src_file,
+                                zf_read.get_input_stream(entry_name, &:read))
   end
 
   def test_add_stored
-    srcFile = 'test/data/file2.txt'
-    entryName = 'newEntryName.rb'
-    assert(::File.exist?(srcFile))
+    src_file = 'test/data/file2.txt'
+    entry_name = 'newEntryName.rb'
+    assert(::File.exist?(src_file))
     zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
-    zf.add_stored(entryName, srcFile)
+    zf.add_stored(entry_name, src_file)
     zf.close
 
-    zfRead = ::Zip::File.new(EMPTY_FILENAME)
-    entry = zfRead.entries.first
-    assert_equal('', zfRead.comment)
-    assert_equal(1, zfRead.entries.length)
-    assert_equal(entryName, entry.name)
-    assert_equal(File.size(srcFile), entry.size)
+    zf_read = ::Zip::File.new(EMPTY_FILENAME)
+    entry = zf_read.entries.first
+    assert_equal('', zf_read.comment)
+    assert_equal(1, zf_read.entries.length)
+    assert_equal(entry_name, entry.name)
+    assert_equal(File.size(src_file), entry.size)
     assert_equal(entry.size, entry.compressed_size)
     assert_equal(::Zip::Entry::STORED, entry.compression_method)
-    AssertEntry.assert_contents(srcFile,
-                                zfRead.get_input_stream(entryName, &:read))
+    AssertEntry.assert_contents(src_file,
+                                zf_read.get_input_stream(entry_name, &:read))
   end
 
   def test_recover_permissions_after_add_files_to_archive
-    srcZip = TEST_ZIP.zip_name
-    ::File.chmod(0o664, srcZip)
-    srcFile = 'test/data/file2.txt'
-    entryName = 'newEntryName.rb'
-    assert_equal(::File.stat(srcZip).mode, 0o100664)
-    assert(::File.exist?(srcZip))
-    zf = ::Zip::File.new(srcZip, ::Zip::File::CREATE)
-    zf.add(entryName, srcFile)
+    src_zip = TEST_ZIP.zip_name
+    ::File.chmod(0o664, src_zip)
+    src_file = 'test/data/file2.txt'
+    entry_name = 'newEntryName.rb'
+    assert_equal(::File.stat(src_zip).mode, 0o100664)
+    assert(::File.exist?(src_zip))
+    zf = ::Zip::File.new(src_zip, ::Zip::File::CREATE)
+    zf.add(entry_name, src_file)
     zf.close
-    assert_equal(::File.stat(srcZip).mode, 0o100664)
+    assert_equal(::File.stat(src_zip).mode, 0o100664)
   end
 
   def test_add_existing_entry_name
@@ -246,18 +246,18 @@ class ZipFileTest < MiniTest::Test
   end
 
   def test_add_existing_entry_name_replace
-    gotCalled = false
-    replacedEntry = nil
+    called = false
+    replaced_entry = nil
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      replacedEntry = zf.entries.first.name
-      zf.add(replacedEntry, 'test/data/file2.txt') do
-        gotCalled = true
+      replaced_entry = zf.entries.first.name
+      zf.add(replaced_entry, 'test/data/file2.txt') do
+        called = true
         true
       end
     end
-    assert(gotCalled)
+    assert(called)
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      assert_contains(zf, replacedEntry, 'test/data/file2.txt')
+      assert_contains(zf, replaced_entry, 'test/data/file2.txt')
     end
   end
 
@@ -265,51 +265,55 @@ class ZipFileTest < MiniTest::Test
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
       zf.add(TestFiles::EMPTY_TEST_DIR, TestFiles::EMPTY_TEST_DIR)
     end
+
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      dirEntry = zf.entries.detect { |e| e.name == TestFiles::EMPTY_TEST_DIR + '/' }
-      assert(dirEntry.directory?)
+      dir_entry = zf.entries.detect do |e|
+        e.name == TestFiles::EMPTY_TEST_DIR + '/'
+      end
+
+      assert(dir_entry.directory?)
     end
   end
 
   def test_remove
-    entryToRemove, *remainingEntries = TEST_ZIP.entry_names
+    entry, *remaining = TEST_ZIP.entry_names
 
     FileUtils.cp(TestZipFile::TEST_ZIP2.zip_name, TEST_ZIP.zip_name)
 
     zf = ::Zip::File.new(TEST_ZIP.zip_name)
-    assert(zf.entries.map(&:name).include?(entryToRemove))
-    zf.remove(entryToRemove)
-    assert(!zf.entries.map(&:name).include?(entryToRemove))
-    assert_equal(zf.entries.map(&:name).sort, remainingEntries.sort)
+    assert(zf.entries.map(&:name).include?(entry))
+    zf.remove(entry)
+    assert(!zf.entries.map(&:name).include?(entry))
+    assert_equal(zf.entries.map(&:name).sort, remaining.sort)
     zf.close
 
-    zfRead = ::Zip::File.new(TEST_ZIP.zip_name)
-    assert(!zfRead.entries.map(&:name).include?(entryToRemove))
-    assert_equal(zfRead.entries.map(&:name).sort, remainingEntries.sort)
-    zfRead.close
+    zf_read = ::Zip::File.new(TEST_ZIP.zip_name)
+    assert(!zf_read.entries.map(&:name).include?(entry))
+    assert_equal(zf_read.entries.map(&:name).sort, remaining.sort)
+    zf_read.close
   end
 
   def test_rename
-    entryToRename, * = TEST_ZIP.entry_names
+    entry, * = TEST_ZIP.entry_names
 
     zf = ::Zip::File.new(TEST_ZIP.zip_name)
-    assert(zf.entries.map(&:name).include?(entryToRename))
+    assert(zf.entries.map(&:name).include?(entry))
 
-    contents = zf.read(entryToRename)
-    newName = 'changed entry name'
-    assert(!zf.entries.map(&:name).include?(newName))
+    contents = zf.read(entry)
+    new_name = 'changed entry name'
+    assert(!zf.entries.map(&:name).include?(new_name))
 
-    zf.rename(entryToRename, newName)
-    assert(zf.entries.map(&:name).include?(newName))
+    zf.rename(entry, new_name)
+    assert(zf.entries.map(&:name).include?(new_name))
 
-    assert_equal(contents, zf.read(newName))
+    assert_equal(contents, zf.read(new_name))
 
     zf.close
 
-    zfRead = ::Zip::File.new(TEST_ZIP.zip_name)
-    assert(zfRead.entries.map(&:name).include?(newName))
-    assert_equal(contents, zfRead.read(newName))
-    zfRead.close
+    zf_read = ::Zip::File.new(TEST_ZIP.zip_name)
+    assert(zf_read.entries.map(&:name).include?(new_name))
+    assert_equal(contents, zf_read.read(new_name))
+    zf_read.close
   end
 
   def test_rename_with_each
@@ -342,8 +346,8 @@ class ZipFileTest < MiniTest::Test
   end
 
   def test_rename_to_existing_entry
-    oldEntries = nil
-    ::Zip::File.open(TEST_ZIP.zip_name) { |zf| oldEntries = zf.entries }
+    old_entries = nil
+    ::Zip::File.open(TEST_ZIP.zip_name) { |zf| old_entries = zf.entries }
 
     assert_raises(::Zip::EntryExistsError) do
       ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
@@ -352,38 +356,38 @@ class ZipFileTest < MiniTest::Test
     end
 
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      assert_equal(oldEntries.sort.map(&:name), zf.entries.sort.map(&:name))
+      assert_equal(old_entries.sort.map(&:name), zf.entries.sort.map(&:name))
     end
   end
 
   def test_rename_to_existing_entry_overwrite
-    oldEntries = nil
-    ::Zip::File.open(TEST_ZIP.zip_name) { |zf| oldEntries = zf.entries }
+    old_entries = nil
+    ::Zip::File.open(TEST_ZIP.zip_name) { |zf| old_entries = zf.entries }
 
-    gotCalled = false
-    renamedEntryName = nil
+    called = false
+    new_entry_name = nil
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      renamedEntryName = zf.entries[0].name
+      new_entry_name = zf.entries[0].name
       zf.rename(zf.entries[0], zf.entries[1].name) do
-        gotCalled = true
+        called = true
         true
       end
     end
 
-    assert(gotCalled)
-    oldEntries.delete_if { |e| e.name == renamedEntryName }
+    assert(called)
+    old_entries.delete_if { |e| e.name == new_entry_name }
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      assert_equal(oldEntries.sort.map(&:name),
+      assert_equal(old_entries.sort.map(&:name),
                    zf.entries.sort.map(&:name))
     end
   end
 
   def test_rename_non_entry
-    nonEntry = 'bogusEntry'
+    non_entry = 'bogusEntry'
     target_entry = 'target_entryName'
     zf = ::Zip::File.new(TEST_ZIP.zip_name)
-    assert(!zf.entries.include?(nonEntry))
-    assert_raises(Errno::ENOENT) { zf.rename(nonEntry, target_entry) }
+    assert(!zf.entries.include?(non_entry))
+    assert_raises(Errno::ENOENT) { zf.rename(non_entry, target_entry) }
     zf.commit
     assert(!zf.entries.include?(target_entry))
   ensure
@@ -399,45 +403,52 @@ class ZipFileTest < MiniTest::Test
   end
 
   def test_replace
-    entryToReplace = TEST_ZIP.entry_names[2]
-    newEntrySrcFilename = 'test/data/file2.txt'
+    replace_entry = TEST_ZIP.entry_names[2]
+    replace_src = 'test/data/file2.txt'
     zf = ::Zip::File.new(TEST_ZIP.zip_name)
-    zf.replace(entryToReplace, newEntrySrcFilename)
+    zf.replace(replace_entry, replace_src)
 
     zf.close
-    zfRead = ::Zip::File.new(TEST_ZIP.zip_name)
-    AssertEntry.assert_contents(newEntrySrcFilename,
-                                zfRead.get_input_stream(entryToReplace, &:read))
-    AssertEntry.assert_contents(TEST_ZIP.entry_names[0],
-                                zfRead.get_input_stream(TEST_ZIP.entry_names[0],
-                                                        &:read))
-    AssertEntry.assert_contents(TEST_ZIP.entry_names[1],
-                                zfRead.get_input_stream(TEST_ZIP.entry_names[1],
-                                                        &:read))
-    AssertEntry.assert_contents(TEST_ZIP.entry_names[3],
-                                zfRead.get_input_stream(TEST_ZIP.entry_names[3],
-                                                        &:read))
-    zfRead.close
+    zf_read = ::Zip::File.new(TEST_ZIP.zip_name)
+    AssertEntry.assert_contents(
+      replace_src,
+      zf_read.get_input_stream(replace_entry, &:read)
+    )
+    AssertEntry.assert_contents(
+      TEST_ZIP.entry_names[0],
+      zf_read.get_input_stream(TEST_ZIP.entry_names[0], &:read)
+    )
+    AssertEntry.assert_contents(
+      TEST_ZIP.entry_names[1],
+      zf_read.get_input_stream(TEST_ZIP.entry_names[1], &:read)
+    )
+    AssertEntry.assert_contents(
+      TEST_ZIP.entry_names[3],
+      zf_read.get_input_stream(TEST_ZIP.entry_names[3], &:read)
+    )
+    zf_read.close
   end
 
   def test_replace_non_entry
-    entryToReplace = 'nonExistingEntryname'
+    replace_entry = 'nonExistingEntryname'
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      assert_raises(Errno::ENOENT) { zf.replace(entryToReplace, 'test/data/file2.txt') }
+      assert_raises(Errno::ENOENT) do
+        zf.replace(replace_entry, 'test/data/file2.txt')
+      end
     end
   end
 
   def test_commit
-    newName = 'renamedFirst'
+    new_name = 'renamedFirst'
     zf = ::Zip::File.new(TEST_ZIP.zip_name)
-    oldName = zf.entries.first
-    zf.rename(oldName, newName)
+    old_name = zf.entries.first
+    zf.rename(old_name, new_name)
     zf.commit
 
-    zfRead = ::Zip::File.new(TEST_ZIP.zip_name)
-    refute_nil(zfRead.entries.detect { |e| e.name == newName })
-    assert_nil(zfRead.entries.detect { |e| e.name == oldName })
-    zfRead.close
+    zf_read = ::Zip::File.new(TEST_ZIP.zip_name)
+    refute_nil(zf_read.entries.detect { |e| e.name == new_name })
+    assert_nil(zf_read.entries.detect { |e| e.name == old_name })
+    zf_read.close
 
     zf.close
     res = system("unzip -tqq #{TEST_ZIP.zip_name}")
@@ -466,17 +477,17 @@ class ZipFileTest < MiniTest::Test
   end
 
   def test_write_buffer
-    newName = 'renamedFirst'
+    new_name = 'renamedFirst'
     zf = ::Zip::File.new(TEST_ZIP.zip_name)
-    oldName = zf.entries.first
-    zf.rename(oldName, newName)
+    old_name = zf.entries.first
+    zf.rename(old_name, new_name)
     io = ::StringIO.new('')
     buffer = zf.write_buffer(io)
     File.open(TEST_ZIP.zip_name, 'wb') { |f| f.write buffer.string }
-    zfRead = ::Zip::File.new(TEST_ZIP.zip_name)
-    refute_nil(zfRead.entries.detect { |e| e.name == newName })
-    assert_nil(zfRead.entries.detect { |e| e.name == oldName })
-    zfRead.close
+    zf_read = ::Zip::File.new(TEST_ZIP.zip_name)
+    refute_nil(zf_read.entries.detect { |e| e.name == new_name })
+    assert_nil(zf_read.entries.detect { |e| e.name == old_name })
+    zf_read.close
 
     zf.close
   end
@@ -503,52 +514,58 @@ class ZipFileTest < MiniTest::Test
   #  end
 
   def test_compound1
-    renamedName = 'renamedName'
+    renamed_name = 'renamed_name'
     filename_to_remove = ''
+
     begin
       zf = ::Zip::File.new(TEST_ZIP.zip_name)
-      originalEntries = zf.entries.dup
+      orig_entries = zf.entries.dup
 
       assert_not_contains(zf, TestFiles::RANDOM_ASCII_FILE1)
       zf.add(TestFiles::RANDOM_ASCII_FILE1,
              TestFiles::RANDOM_ASCII_FILE1)
       assert_contains(zf, TestFiles::RANDOM_ASCII_FILE1)
 
-      entry_to_rename = zf.entries.find { |entry| entry.name.match('longAscii') }
-      zf.rename(entry_to_rename, renamedName)
-      assert_contains(zf, renamedName)
+      entry_to_rename = zf.entries.find do |entry|
+        entry.name.match('longAscii')
+      end
+      zf.rename(entry_to_rename, renamed_name)
+      assert_contains(zf, renamed_name)
 
       TestFiles::BINARY_TEST_FILES.each do |filename|
         zf.add(filename, filename)
         assert_contains(zf, filename)
       end
 
-      assert_contains(zf, originalEntries.last.to_s)
-      filename_to_remove = originalEntries.map(&:to_s).find { |name| name.match('longBinary') }
+      assert_contains(zf, orig_entries.last.to_s)
+      filename_to_remove = orig_entries.map(&:to_s).find do |name|
+        name.match('longBinary')
+      end
       zf.remove(filename_to_remove)
       assert_not_contains(zf, filename_to_remove)
     ensure
       zf.close
     end
+
     begin
-      zfRead = ::Zip::File.new(TEST_ZIP.zip_name)
-      assert_contains(zfRead, TestFiles::RANDOM_ASCII_FILE1)
-      assert_contains(zfRead, renamedName)
+      zf_read = ::Zip::File.new(TEST_ZIP.zip_name)
+      assert_contains(zf_read, TestFiles::RANDOM_ASCII_FILE1)
+      assert_contains(zf_read, renamed_name)
       TestFiles::BINARY_TEST_FILES.each do |filename|
-        assert_contains(zfRead, filename)
+        assert_contains(zf_read, filename)
       end
-      assert_not_contains(zfRead, filename_to_remove)
+      assert_not_contains(zf_read, filename_to_remove)
     ensure
-      zfRead.close
+      zf_read.close
     end
   end
 
   def test_compound2
     begin
       zf = ::Zip::File.new(TEST_ZIP.zip_name)
-      originalEntries = zf.entries.dup
+      orig_entries = zf.entries.dup
 
-      originalEntries.each do |entry|
+      orig_entries.each do |entry|
         zf.remove(entry)
         assert_not_contains(zf, entry)
       end
@@ -560,23 +577,23 @@ class ZipFileTest < MiniTest::Test
       end
       assert_equal(zf.entries.sort.map(&:name), TestFiles::ASCII_TEST_FILES)
 
-      zf.rename(TestFiles::ASCII_TEST_FILES[0], 'newName')
+      zf.rename(TestFiles::ASCII_TEST_FILES[0], 'new_name')
       assert_not_contains(zf, TestFiles::ASCII_TEST_FILES[0])
-      assert_contains(zf, 'newName')
+      assert_contains(zf, 'new_name')
     ensure
       zf.close
     end
     begin
-      zfRead = ::Zip::File.new(TEST_ZIP.zip_name)
-      asciiTestFiles = TestFiles::ASCII_TEST_FILES.dup
-      asciiTestFiles.shift
-      asciiTestFiles.each do |filename|
+      zf_read = ::Zip::File.new(TEST_ZIP.zip_name)
+      ascii_files = TestFiles::ASCII_TEST_FILES.dup
+      ascii_files.shift
+      ascii_files.each do |filename|
         assert_contains(zf, filename)
       end
 
-      assert_contains(zf, 'newName')
+      assert_contains(zf, 'new_name')
     ensure
-      zfRead.close
+      zf_read.close
     end
   end
 
@@ -584,31 +601,31 @@ class ZipFileTest < MiniTest::Test
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
       zf.comment = 'my changed comment'
     end
-    zfRead = ::Zip::File.open(TEST_ZIP.zip_name)
-    assert_equal('my changed comment', zfRead.comment)
+    zf_read = ::Zip::File.open(TEST_ZIP.zip_name)
+    assert_equal('my changed comment', zf_read.comment)
   end
 
   def test_preserve_file_order
-    entryNames = nil
+    entry_names = nil
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      entryNames = zf.entries.map(&:to_s)
+      entry_names = zf.entries.map(&:to_s)
       zf.get_output_stream('a.txt') { |os| os.write 'this is a.txt' }
       zf.get_output_stream('z.txt') { |os| os.write 'this is z.txt' }
       zf.get_output_stream('k.txt') { |os| os.write 'this is k.txt' }
-      entryNames << 'a.txt' << 'z.txt' << 'k.txt'
+      entry_names << 'a.txt' << 'z.txt' << 'k.txt'
     end
 
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      assert_equal(entryNames, zf.entries.map(&:to_s))
+      assert_equal(entry_names, zf.entries.map(&:to_s))
       entries = zf.entries.sort_by(&:name).reverse
       entries.each do |e|
         zf.remove e
         zf.get_output_stream(e) { |os| os.write 'foo' }
       end
-      entryNames = entries.map(&:to_s)
+      entry_names = entries.map(&:to_s)
     end
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      assert_equal(entryNames, zf.entries.map(&:to_s))
+      assert_equal(entry_names, zf.entries.map(&:to_s))
     end
   end
 

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -680,12 +680,18 @@ class ZipFileTest < MiniTest::Test
 
   private
 
-  def assert_contains(zf, entryName, filename = entryName)
-    refute_nil(zf.entries.detect { |e| e.name == entryName }, "entry #{entryName} not in #{zf.entries.join(', ')} in zip file #{zf}")
-    assert_entry_contents(zf, entryName, filename) if File.exist?(filename)
+  def assert_contains(zip_file, entry_name, filename = entry_name)
+    refute_nil(
+      zip_file.entries.detect { |e| e.name == entry_name },
+      "entry #{entry_name} not in #{zip_file.entries.join(', ')} in zip file #{zip_file}"
+    )
+    assert_entry_contents(zip_file, entry_name, filename) if File.exist?(filename)
   end
 
-  def assert_not_contains(zf, entryName)
-    assert_nil(zf.entries.detect { |e| e.name == entryName }, "entry #{entryName} in #{zf.entries.join(', ')} in zip file #{zf}")
+  def assert_not_contains(zip_file, entry_name)
+    assert_nil(
+      zip_file.entries.detect { |e| e.name == entry_name },
+      "entry #{entry_name} in #{zip_file.entries.join(', ')} in zip file #{zip_file}"
+    )
   end
 end

--- a/test/filesystem/dir_iterator_test.rb
+++ b/test/filesystem/dir_iterator_test.rb
@@ -5,54 +5,54 @@ class ZipFsDirIteratorTest < MiniTest::Test
   FILENAME_ARRAY = %w[f1 f2 f3 f4 f5 f6]
 
   def setup
-    @dirIt = ::Zip::FileSystem::ZipFsDirIterator.new(FILENAME_ARRAY)
+    @dir_iter = ::Zip::FileSystem::ZipFsDirIterator.new(FILENAME_ARRAY)
   end
 
   def test_close
-    @dirIt.close
+    @dir_iter.close
     assert_raises(IOError, 'closed directory') do
-      @dirIt.each { |e| p e }
+      @dir_iter.each { |e| p e }
     end
     assert_raises(IOError, 'closed directory') do
-      @dirIt.read
+      @dir_iter.read
     end
     assert_raises(IOError, 'closed directory') do
-      @dirIt.rewind
+      @dir_iter.rewind
     end
     assert_raises(IOError, 'closed directory') do
-      @dirIt.seek(0)
+      @dir_iter.seek(0)
     end
     assert_raises(IOError, 'closed directory') do
-      @dirIt.tell
+      @dir_iter.tell
     end
   end
 
   def test_each
     # Tested through Enumerable.entries
-    assert_equal(FILENAME_ARRAY, @dirIt.entries)
+    assert_equal(FILENAME_ARRAY, @dir_iter.entries)
   end
 
   def test_read
     FILENAME_ARRAY.size.times do |i|
-      assert_equal(FILENAME_ARRAY[i], @dirIt.read)
+      assert_equal(FILENAME_ARRAY[i], @dir_iter.read)
     end
   end
 
   def test_rewind
-    @dirIt.read
-    @dirIt.read
-    assert_equal(FILENAME_ARRAY[2], @dirIt.read)
-    @dirIt.rewind
-    assert_equal(FILENAME_ARRAY[0], @dirIt.read)
+    @dir_iter.read
+    @dir_iter.read
+    assert_equal(FILENAME_ARRAY[2], @dir_iter.read)
+    @dir_iter.rewind
+    assert_equal(FILENAME_ARRAY[0], @dir_iter.read)
   end
 
   def test_tell_seek
-    @dirIt.read
-    @dirIt.read
-    pos = @dirIt.tell
-    valAtPos = @dirIt.read
-    @dirIt.read
-    @dirIt.seek(pos)
-    assert_equal(valAtPos, @dirIt.read)
+    @dir_iter.read
+    @dir_iter.read
+    pos = @dir_iter.tell
+    value = @dir_iter.read
+    @dir_iter.read
+    @dir_iter.seek(pos)
+    assert_equal(value, @dir_iter.read)
   end
 end

--- a/test/filesystem/directory_test.rb
+++ b/test/filesystem/directory_test.rb
@@ -65,16 +65,16 @@ class ZipFsDirectoryTest < MiniTest::Test
 
   def test_foreach
     ::Zip::File.open(TEST_ZIP) do |zf|
-      blockCalled = false
+      block_called = false
       assert_raises(Errno::ENOENT, 'No such file or directory - noSuchDir') do
-        zf.dir.foreach('noSuchDir') { |_e| blockCalled = true }
+        zf.dir.foreach('noSuchDir') { |_e| block_called = true }
       end
-      assert(!blockCalled)
+      assert(!block_called)
 
       assert_raises(Errno::ENOTDIR, 'Not a directory - file1') do
-        zf.dir.foreach('file1') { |_e| blockCalled = true }
+        zf.dir.foreach('file1') { |_e| block_called = true }
       end
-      assert(!blockCalled)
+      assert(!block_called)
 
       entries = []
       zf.dir.foreach('.') { |e| entries << e }

--- a/test/filesystem/file_nonmutating_test.rb
+++ b/test/filesystem/file_nonmutating_test.rb
@@ -31,30 +31,30 @@ class ZipFsFileNonmutatingTest < MiniTest::Test
   end
 
   def test_open_read
-    blockCalled = false
+    block_called = false
     @zip_file.file.open('file1', 'r') do |f|
-      blockCalled = true
+      block_called = true
       assert_equal("this is the entry 'file1' in my test archive!",
                    f.readline.chomp)
     end
-    assert(blockCalled)
+    assert(block_called)
 
-    blockCalled = false
+    block_called = false
     @zip_file.file.open('file1', 'rb') do |f| # test binary flag is ignored
-      blockCalled = true
+      block_called = true
       assert_equal("this is the entry 'file1' in my test archive!",
                    f.readline.chomp)
     end
-    assert(blockCalled)
+    assert(block_called)
 
-    blockCalled = false
+    block_called = false
     @zip_file.dir.chdir 'dir2'
     @zip_file.file.open('file21', 'r') do |f|
-      blockCalled = true
+      block_called = true
       assert_equal("this is the entry 'dir2/file21' in my test archive!",
                    f.readline.chomp)
     end
-    assert(blockCalled)
+    assert(block_called)
     @zip_file.dir.chdir '/'
 
     assert_raises(Errno::ENOENT) do
@@ -126,19 +126,19 @@ class ZipFsFileNonmutatingTest < MiniTest::Test
   include ExtraAssertions
 
   def test_dirname
-    assert_forwarded(File, :dirname, 'retVal', 'a/b/c/d') do
+    assert_forwarded(File, :dirname, 'ret_val', 'a/b/c/d') do
       @zip_file.file.dirname('a/b/c/d')
     end
   end
 
   def test_basename
-    assert_forwarded(File, :basename, 'retVal', 'a/b/c/d') do
+    assert_forwarded(File, :basename, 'ret_val', 'a/b/c/d') do
       @zip_file.file.basename('a/b/c/d')
     end
   end
 
   def test_split
-    assert_forwarded(File, :split, 'retVal', 'a/b/c/d') do
+    assert_forwarded(File, :split, 'ret_val', 'a/b/c/d') do
       @zip_file.file.split('a/b/c/d')
     end
   end
@@ -246,21 +246,21 @@ class ZipFsFileNonmutatingTest < MiniTest::Test
     assert(!@zip_file.file.zero?('notAFile'))
     assert(!@zip_file.file.zero?('file1'))
     assert(@zip_file.file.zero?('dir1'))
-    blockCalled = false
+    block_called = false
     ::Zip::File.open('test/data/generated/5entry.zip') do |zf|
-      blockCalled = true
+      block_called = true
       assert(zf.file.zero?('test/data/generated/empty.txt'))
     end
-    assert(blockCalled)
+    assert(block_called)
 
     assert(!@zip_file.file.stat('file1').zero?)
     assert(@zip_file.file.stat('dir1').zero?)
-    blockCalled = false
+    block_called = false
     ::Zip::File.open('test/data/generated/5entry.zip') do |zf|
-      blockCalled = true
+      block_called = true
       assert(zf.file.stat('test/data/generated/empty.txt').zero?)
     end
-    assert(blockCalled)
+    assert(block_called)
   end
 
   def test_expand_path

--- a/test/gentestfiles.rb
+++ b/test/gentestfiles.rb
@@ -84,18 +84,20 @@ class TestZipFile
     ::File.chmod(0o640, 'test/data/generated/empty_chmod640.txt')
 
     File.open('test/data/generated/short.txt', 'w') { |file| file << 'ABCDEF' }
-    ziptestTxt = ''
-    File.open('test/data/file2.txt') { |file| ziptestTxt = file.read }
+    test_text = ''
+    File.open('test/data/file2.txt') { |file| test_text = file.read }
     File.open('test/data/generated/longAscii.txt', 'w') do |file|
-      file << ziptestTxt while file.tell < 1E5
+      file << test_text while file.tell < 1E5
     end
 
-    testBinaryPattern = ''
-    File.open('test/data/generated/empty.zip') { |file| testBinaryPattern = file.read }
-    testBinaryPattern *= 4
+    binary_pattern = ''
+    File.open('test/data/generated/empty.zip') do |file|
+      binary_pattern = file.read
+    end
+    binary_pattern *= 4
 
     File.open('test/data/generated/longBinary.bin', 'wb') do |file|
-      file << testBinaryPattern << rand << "\0" while file.tell < 6E5
+      file << binary_pattern << rand << "\0" while file.tell < 6E5
     end
 
     raise "failed to create test zip '#{TEST_ZIP2.zip_name}'" \

--- a/test/ioextras/abstract_input_stream_test.rb
+++ b/test/ioextras/abstract_input_stream_test.rb
@@ -11,15 +11,15 @@ class AbstractInputStreamTest < MiniTest::Test
   class TestAbstractInputStream
     include ::Zip::IOExtras::AbstractInputStream
 
-    def initialize(aString)
+    def initialize(string)
       super()
-      @contents = aString
+      @contents = string
       @readPointer = 0
     end
 
-    def sysread(charsToRead, _buf = nil)
-      retVal = @contents[@readPointer, charsToRead]
-      @readPointer += charsToRead
+    def sysread(chars_to_read, _buf = nil)
+      retVal = @contents[@readPointer, chars_to_read]
+      @readPointer += chars_to_read
       retVal
     end
 

--- a/test/ioextras/abstract_input_stream_test.rb
+++ b/test/ioextras/abstract_input_stream_test.rb
@@ -14,13 +14,13 @@ class AbstractInputStreamTest < MiniTest::Test
     def initialize(string)
       super()
       @contents = string
-      @readPointer = 0
+      @read_ptr = 0
     end
 
     def sysread(chars_to_read, _buf = nil)
-      retVal = @contents[@readPointer, chars_to_read]
-      @readPointer += chars_to_read
-      retVal
+      ret_val = @contents[@read_ptr, chars_to_read]
+      @read_ptr += chars_to_read
+      ret_val
     end
 
     def produce_input
@@ -28,7 +28,7 @@ class AbstractInputStreamTest < MiniTest::Test
     end
 
     def input_finished?
-      @contents[@readPointer].nil?
+      @contents[@read_ptr].nil?
     end
   end
 
@@ -80,10 +80,10 @@ class AbstractInputStreamTest < MiniTest::Test
   end
 
   def test_each_line
-    lineNumber = 0
+    line_num = 0
     @io.each_line do |line|
-      assert_equal(TEST_LINES[lineNumber], line)
-      lineNumber += 1
+      assert_equal(TEST_LINES[line_num], line)
+      line_num += 1
     end
   end
 

--- a/test/ioextras/abstract_output_stream_test.rb
+++ b/test/ioextras/abstract_output_stream_test.rb
@@ -20,13 +20,13 @@ class AbstractOutputStreamTest < MiniTest::Test
   def setup
     @output_stream = TestOutputStream.new
 
-    @origCommaSep = $OUTPUT_FIELD_SEPARATOR
-    @origOutputSep = $OUTPUT_RECORD_SEPARATOR
+    @save_comma_sep = $OUTPUT_FIELD_SEPARATOR
+    @save_output_sep = $OUTPUT_RECORD_SEPARATOR
   end
 
   def teardown
-    $, = @origCommaSep
-    $\ = @origOutputSep
+    $, = @save_comma_sep
+    $\ = @save_output_sep
   end
 
   def test_write

--- a/test/local_entry_test.rb
+++ b/test/local_entry_test.rb
@@ -139,16 +139,16 @@ class ZipLocalEntryTest < MiniTest::Test
     assert_equal(entry1.comment, entry2.comment)
   end
 
-  def write_to_file(localFileName, centralFileName, entry)
-    ::File.open(localFileName, 'wb') { |f| entry.write_local_entry(f) }
-    ::File.open(centralFileName, 'wb') { |f| entry.write_c_dir_entry(f) }
+  def write_to_file(local_filename, central_filename, entry)
+    ::File.open(local_filename, 'wb') { |f| entry.write_local_entry(f) }
+    ::File.open(central_filename, 'wb') { |f| entry.write_c_dir_entry(f) }
   end
 
-  def read_from_file(localFileName, centralFileName)
+  def read_from_file(local_filename, central_filename)
     localEntry = nil
     cdirEntry = nil
-    ::File.open(localFileName, 'rb') { |f| localEntry = ::Zip::Entry.read_local_entry(f) }
-    ::File.open(centralFileName, 'rb') { |f| cdirEntry = ::Zip::Entry.read_c_dir_entry(f) }
+    ::File.open(local_filename, 'rb') { |f| localEntry = ::Zip::Entry.read_local_entry(f) }
+    ::File.open(central_filename, 'rb') { |f| cdirEntry = ::Zip::Entry.read_c_dir_entry(f) }
     [localEntry, cdirEntry]
   end
 end

--- a/test/local_entry_test.rb
+++ b/test/local_entry_test.rb
@@ -41,56 +41,71 @@ class ZipLocalEntryTest < MiniTest::Test
   end
 
   def test_read_local_entry_from_truncated_zip_file
-    zipFragment = ''
-    ::File.open(TestZipFile::TEST_ZIP2.zip_name) { |f| zipFragment = f.read(12) } # local header is at least 30 bytes
-    zipFragment.extend(IOizeString).reset
+    fragment = ''
+    # local header is at least 30 bytes
+    ::File.open(TestZipFile::TEST_ZIP2.zip_name) { |f| fragment = f.read(12) }
+
+    fragment.extend(IOizeString).reset
     entry = ::Zip::Entry.new
-    entry.read_local_entry(zipFragment)
+    entry.read_local_entry(fragment)
     raise 'ZipError expected'
   rescue ::Zip::Error
   end
 
   def test_write_entry
-    entry = ::Zip::Entry.new('file.zip', 'entryName', 'my little comment',
+    entry = ::Zip::Entry.new('file.zip', 'entry_name', 'my little comment',
                              'thisIsSomeExtraInformation', 100, 987_654,
                              ::Zip::Entry::DEFLATED, 400)
     write_to_file(LEH_FILE, CEH_FILE, entry)
-    entryReadLocal, entryReadCentral = read_from_file(LEH_FILE, CEH_FILE)
-    assert(entryReadCentral.extra['Zip64Placeholder'].nil?, 'zip64 placeholder should not be used in central directory')
-    compare_local_entry_headers(entry, entryReadLocal)
-    compare_c_dir_entry_headers(entry, entryReadCentral)
+    local_entry, central_entry = read_from_file(LEH_FILE, CEH_FILE)
+    assert(
+      central_entry.extra['Zip64Placeholder'].nil?,
+      'zip64 placeholder should not be used in central directory'
+    )
+    compare_local_entry_headers(entry, local_entry)
+    compare_c_dir_entry_headers(entry, central_entry)
   end
 
   def test_write_entry_with_zip64
     ::Zip.write_zip64_support = true
-    entry = ::Zip::Entry.new('file.zip', 'entryName', 'my little comment',
+    entry = ::Zip::Entry.new('file.zip', 'entry_name', 'my little comment',
                              'thisIsSomeExtraInformation', 100, 987_654,
                              ::Zip::Entry::DEFLATED, 400)
+
     write_to_file(LEH_FILE, CEH_FILE, entry)
-    entryReadLocal, entryReadCentral = read_from_file(LEH_FILE, CEH_FILE)
-    assert(entryReadLocal.extra['Zip64Placeholder'], 'zip64 placeholder should be used in local file header')
-    entryReadLocal.extra.delete('Zip64Placeholder') # it was removed when writing the c_dir_entry, so remove from compare
-    assert(entryReadCentral.extra['Zip64Placeholder'].nil?, 'zip64 placeholder should not be used in central directory')
-    compare_local_entry_headers(entry, entryReadLocal)
-    compare_c_dir_entry_headers(entry, entryReadCentral)
+    local_entry, central_entry = read_from_file(LEH_FILE, CEH_FILE)
+    assert(
+      local_entry.extra['Zip64Placeholder'],
+      'zip64 placeholder should be used in local file header'
+    )
+
+    # This was removed when writing the c_dir_entry, so remove from compare.
+    local_entry.extra.delete('Zip64Placeholder')
+    assert(
+      central_entry.extra['Zip64Placeholder'].nil?,
+      'zip64 placeholder should not be used in central directory'
+    )
+
+    compare_local_entry_headers(entry, local_entry)
+    compare_c_dir_entry_headers(entry, central_entry)
   end
 
   def test_write_64entry
     ::Zip.write_zip64_support = true
-    entry = ::Zip::Entry.new('bigfile.zip', 'entryName', 'my little equine',
+    entry = ::Zip::Entry.new('bigfile.zip', 'entry_name', 'my little equine',
                              'malformed extra field because why not',
                              0x7766554433221100, 0xDEADBEEF, ::Zip::Entry::DEFLATED,
                              0x9988776655443322)
     write_to_file(LEH_FILE, CEH_FILE, entry)
-    entryReadLocal, entryReadCentral = read_from_file(LEH_FILE, CEH_FILE)
-    compare_local_entry_headers(entry, entryReadLocal)
-    compare_c_dir_entry_headers(entry, entryReadCentral)
+    local_entry, central_entry = read_from_file(LEH_FILE, CEH_FILE)
+    compare_local_entry_headers(entry, local_entry)
+    compare_c_dir_entry_headers(entry, central_entry)
   end
 
   def test_rewrite_local_header64
     ::Zip.write_zip64_support = true
     buf1 = StringIO.new
-    entry = ::Zip::Entry.new('file.zip', 'entryName')
+    entry = ::Zip::Entry.new('file.zip', 'entry_name')
     entry.write_local_entry(buf1)
     assert(entry.extra['Zip64'].nil?, 'zip64 extra is unnecessarily present')
 
@@ -104,7 +119,7 @@ class ZipLocalEntryTest < MiniTest::Test
   end
 
   def test_read_local_offset
-    entry = ::Zip::Entry.new('file.zip', 'entryName')
+    entry = ::Zip::Entry.new('file.zip', 'entry_name')
     entry.local_header_offset = 12_345
     ::File.open(CEH_FILE, 'wb') { |f| entry.write_c_dir_entry(f) }
     read_entry = nil
@@ -114,7 +129,7 @@ class ZipLocalEntryTest < MiniTest::Test
 
   def test_read64_local_offset
     ::Zip.write_zip64_support = true
-    entry = ::Zip::Entry.new('file.zip', 'entryName')
+    entry = ::Zip::Entry.new('file.zip', 'entry_name')
     entry.local_header_offset = 0x0123456789ABCDEF
     ::File.open(CEH_FILE, 'wb') { |f| entry.write_c_dir_entry(f) }
     read_entry = nil
@@ -145,10 +160,17 @@ class ZipLocalEntryTest < MiniTest::Test
   end
 
   def read_from_file(local_filename, central_filename)
-    localEntry = nil
-    cdirEntry = nil
-    ::File.open(local_filename, 'rb') { |f| localEntry = ::Zip::Entry.read_local_entry(f) }
-    ::File.open(central_filename, 'rb') { |f| cdirEntry = ::Zip::Entry.read_c_dir_entry(f) }
-    [localEntry, cdirEntry]
+    local_entry = nil
+    cdir_entry = nil
+
+    ::File.open(local_filename, 'rb') do |f|
+      local_entry = ::Zip::Entry.read_local_entry(f)
+    end
+
+    ::File.open(central_filename, 'rb') do |f|
+      cdir_entry = ::Zip::Entry.read_c_dir_entry(f)
+    end
+
+    [local_entry, cdir_entry]
   end
 end

--- a/test/output_stream_test.rb
+++ b/test/output_stream_test.rb
@@ -121,9 +121,9 @@ class ZipOutputStreamTest < MiniTest::Test
   end
 
   def write_test_zip(zos)
-    TEST_ZIP.entry_names.each do |entryName|
-      zos.put_next_entry(entryName)
-      File.open(entryName, 'rb') { |f| zos.write(f.read) }
+    TEST_ZIP.entry_names.each do |entry_name|
+      zos.put_next_entry(entry_name)
+      File.open(entry_name, 'rb') { |f| zos.write(f.read) }
     end
   end
 end

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -54,15 +54,15 @@ class ZipSettingsTest < MiniTest::Test
   def test_true_continue_on_exists_proc
     Zip.continue_on_exists_proc = true
 
-    replacedEntry = nil
+    replaced_entry = nil
 
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      replacedEntry = zf.entries.first.name
-      zf.add(replacedEntry, 'test/data/file2.txt')
+      replaced_entry = zf.entries.first.name
+      zf.add(replaced_entry, 'test/data/file2.txt')
     end
 
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
-      assert_contains(zf, replacedEntry, 'test/data/file2.txt')
+      assert_contains(zf, replaced_entry, 'test/data/file2.txt')
     end
   end
 

--- a/test/settings_test.rb
+++ b/test/settings_test.rb
@@ -17,14 +17,14 @@ class ZipSettingsTest < MiniTest::Test
     ::Zip.reset!
   end
 
-  def open_zip(&aProc)
-    refute_nil(aProc)
-    ::Zip::File.open(TestZipFile::TEST_ZIP4.zip_name, &aProc)
+  def open_zip(&a_proc)
+    refute_nil(a_proc)
+    ::Zip::File.open(TestZipFile::TEST_ZIP4.zip_name, &a_proc)
   end
 
-  def extract_test_dir(&aProc)
+  def extract_test_dir(&a_proc)
     open_zip do |zf|
-      zf.extract(TestFiles::EMPTY_TEST_DIR, TEST_OUT_NAME, &aProc)
+      zf.extract(TestFiles::EMPTY_TEST_DIR, TEST_OUT_NAME, &a_proc)
     end
   end
 
@@ -88,8 +88,11 @@ class ZipSettingsTest < MiniTest::Test
 
   private
 
-  def assert_contains(zf, entryName, filename = entryName)
-    refute_nil(zf.entries.detect { |e| e.name == entryName }, "entry #{entryName} not in #{zf.entries.join(', ')} in zip file #{zf}")
-    assert_entry_contents(zf, entryName, filename) if File.exist?(filename)
+  def assert_contains(zip_file, entry_name, filename = entry_name)
+    refute_nil(
+      zip_file.entries.detect { |e| e.name == entry_name },
+      "entry #{entry_name} not in #{zip_file.entries.join(', ')} in zip file #{zip_file}"
+    )
+    assert_entry_contents(zip_file, entry_name, filename) if File.exist?(filename)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -119,8 +119,8 @@ module AssertEntry
 
   def assert_stream_contents(zis, testZipFile)
     assert(!zis.nil?)
-    testZipFile.entry_names.each do |entryName|
-      assert_next_entry(entryName, zis)
+    testZipFile.entry_names.each do |entry_name|
+      assert_next_entry(entry_name, zis)
     end
     assert_nil(zis.get_next_entry)
   end


### PR DESCRIPTION
This PR goes through and cleans up rubocop naming cops that don't affect the API.

There were many variables/parameters/etc named in `camelCase` style, possibly a hangover from the early days of this library and its Java-like roots. This PR renames them to ruby standard `snake_case` style.

Most names have been translated as simply as possible - e.g. `entryName` to `entry_name` - but some have been simplified as well - e.g. `aProc` to `proc`. There are no changes to functionality in this PR; any other changes, such as formatting, have only been done to conform to our existing rubocop standards.