### PR TITLE
test/file_extract_test.rb: fix test_extract_incorrect_size in s390x arch

### DIFF
--- a/test/file_extract_test.rb
+++ b/test/file_extract_test.rb
@@ -110,8 +110,8 @@ class ZipFileExtractTest < MiniTest::Test
         assert_equal true_size, a_entry.size
       end
 
-      true_size_bytes = [compressed_size, true_size, file_name.size].pack('LLS')
-      fake_size_bytes = [compressed_size, fake_size, file_name.size].pack('LLS')
+      true_size_bytes = [compressed_size, true_size, file_name.size].pack('VVv')
+      fake_size_bytes = [compressed_size, fake_size, file_name.size].pack('VVv')
 
       data = File.binread(real_zip)
       assert data.include?(true_size_bytes)


### PR DESCRIPTION
Using the current pack directives makes test_extract_incorrect_size fail
in s390x architecture because of the endian probably. This is the output
of the command executed by the test in amd64:

irb(main):001:0> [501, 500000, 1].pack('LLS')
=> "\xF5\x01\x00\x00 \xA1\a\x00\x01\x00"

And the output of the same command in s390x:

irb(main):001:0> [501, 500000, 1].pack('LLS')
=> "\x00\x00\x01\xF5\x00\a\xA1 \x00\x01"

Changing to 'V' pack directive like is used in
lib/zib/central_directory.rb fixes the test in s390x and does not add a
regression in amd64.


FTR I've faced this issue in ruby-zip Debian package in Ubuntu, here is the log: https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-focal/focal/s390x/r/ruby-zip/20200323_152440_d8d79@/log.gz