### PR TITLE
Fix zlib deflate buffer growth

### DIFF
--- a/lib/zip/deflater.rb
+++ b/lib/zip/deflater.rb
@@ -13,7 +13,7 @@ module Zip
       val   = data.to_s
       @crc  = Zlib.crc32(val, @crc)
       @size += val.bytesize
-      buffer = @zlib_deflater.deflate(data)
+      buffer = @zlib_deflater.deflate(data, Zlib::SYNC_FLUSH)
       if buffer.empty?
         @output_stream
       else
@@ -22,7 +22,9 @@ module Zip
     end
 
     def finish
-      @output_stream << @encrypter.encrypt(@zlib_deflater.finish) until @zlib_deflater.finished?
+      buffer = @zlib_deflater.finish
+      @output_stream << @encrypter.encrypt(buffer) unless buffer.empty?
+      @zlib_deflater.close
     end
 
     attr_reader :size, :crc

--- a/lib/zip/deflater.rb
+++ b/lib/zip/deflater.rb
@@ -14,11 +14,9 @@ module Zip
       @crc  = Zlib.crc32(val, @crc)
       @size += val.bytesize
       buffer = @zlib_deflater.deflate(data, Zlib::SYNC_FLUSH)
-      if buffer.empty?
-        @output_stream
-      else
-        @output_stream << @encrypter.encrypt(buffer)
-      end
+      return @output_stream if buffer.empty?
+
+      @output_stream << @encrypter.encrypt(buffer)
     end
 
     def finish

--- a/test/encryption_test.rb
+++ b/test/encryption_test.rb
@@ -14,20 +14,28 @@ class EncryptionTest < MiniTest::Test
   end
 
   def test_encrypt
-    test_file = ::File.open(ENCRYPT_ZIP_TEST_FILE, 'rb').read
+    content = File.open(INPUT_FILE1, 'r').read
+    test_filename = 'top_secret_file.txt'
 
-    @rand = [250, 143, 107, 13, 143, 22, 155, 75, 228, 150, 12]
-    @output = ::Zip::DOSTime.stub(:now, ::Zip::DOSTime.new(2014, 12, 17, 15, 56, 24)) do
-      Random.stub(:rand, ->(_range) { @rand.shift }) do
-        Zip::OutputStream.write_buffer(::StringIO.new(''), Zip::TraditionalEncrypter.new('password')) do |zos|
-          zos.put_next_entry('file1.txt')
-          zos.write ::File.open(INPUT_FILE1).read
-        end.string
-      end
+    password = 'swordfish'
+
+    encrypted_zip = Zip::OutputStream.write_buffer(::StringIO.new(''), Zip::TraditionalEncrypter.new(password)) do |out|
+      out.put_next_entry(test_filename)
+      out.write content
     end
 
-    @output.unpack('C*').each_with_index do |c, i|
-      assert_equal test_file[i].ord, c
+    Zip::InputStream.open(encrypted_zip, 0, Zip::TraditionalDecrypter.new(password)) do |zis|
+      entry = zis.get_next_entry
+      assert_equal test_filename, entry.name
+      assert_equal 1327, entry.size
+      assert_equal content, zis.read
+    end
+
+    assert_raises(Zip::DecompressionError) do
+      Zip::InputStream.open(encrypted_zip, 0, Zip::TraditionalDecrypter.new(password + 'wrong')) do |zis|
+        zis.get_next_entry
+        assert_equal content, zis.read
+      end
     end
   end
 


### PR DESCRIPTION
With jruby there was problem when creating large zipped files. I found that deflate did not flush zlib stream like it did with cruby.