### PR TITLE
Fix input stream partial read error.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # X.X.X (Next)
 
+- Fix input stream partial read error. [#462](https://github.com/rubyzip/rubyzip/pull/462)
+
 Tooling:
 
 - Update rubocop again and run it in CI. [#444](https://github.com/rubyzip/rubyzip/pull/444)

--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -19,7 +19,7 @@ module Zip
 
       def read(number_of_bytes = nil, buf = '')
         tbuf = if @output_buffer.bytesize > 0
-                 if number_of_bytes <= @output_buffer.bytesize
+                 if number_of_bytes && number_of_bytes <= @output_buffer.bytesize
                    @output_buffer.slice!(0, number_of_bytes)
                  else
                    number_of_bytes -= @output_buffer.bytesize if number_of_bytes

--- a/test/input_stream_test.rb
+++ b/test/input_stream_test.rb
@@ -179,4 +179,14 @@ class ZipInputStreamTest < MiniTest::Test
       assert_equal('$VERBOSE =', zis.read(10))
     end
   end
+
+  def test_readline_then_read
+    ::Zip::InputStream.open(TestZipFile::TEST_ZIP2.zip_name) do |zis|
+      zis.get_next_entry
+      assert_equal("#!/usr/bin/env ruby\n", zis.readline)
+      refute(zis.eof?)
+      refute_empty(zis.read) # Also should not raise an error.
+      assert(zis.eof?)
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #461.

If an input stream has been read from, and left some data in the internal buffer, then a subsequent `read`, with no amount of bytes to be read having been specified, will raise an error when comparing to `nil`. This fix checks that the number of bytes specified in the `read` is not `nil` before comparing with the size of the internal buffer.