### PR TITLE
Replace and deprecate `Zip::DOSTime#dos_equals`.

### DIFF
--- a/lib/zip/dos_time.rb
+++ b/lib/zip/dos_time.rb
@@ -24,9 +24,14 @@ module Zip
         ((year - 1980) << 9)
     end
 
-    # Dos time is only stored with two seconds accuracy
     def dos_equals(other)
-      to_i / 2 == other.to_i / 2
+      warn 'Zip::DOSTime#dos_equals is deprecated. Use `==` instead.'
+      self == other
+    end
+
+    # Dos time is only stored with two seconds accuracy.
+    def <=>(other)
+      (to_i / 2) <=> (other.to_i / 2)
     end
 
     # Create a DOSTime instance from a vanilla Time instance.

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -503,10 +503,9 @@ module Zip
       return false unless other.class == self.class
 
       # Compares contents of local entry and exposed fields
-      keys_equal = %w[compression_method crc compressed_size size name extra filepath].all? do |k|
+      %w[compression_method crc compressed_size size name extra filepath time].all? do |k|
         other.__send__(k.to_sym) == __send__(k.to_sym)
       end
-      keys_equal && time.dos_equals(other.time)
     end
 
     def <=>(other)

--- a/test/output_stream_test.rb
+++ b/test/output_stream_test.rb
@@ -100,7 +100,7 @@ class ZipOutputStreamTest < MiniTest::Test
     ::Zip::InputStream.open(TEST_ZIP.zip_name) do |io|
       while (entry = io.get_next_entry)
         # Compare DOS Times, since they are stored with two seconds accuracy
-        assert(::Zip::DOSTime.at(file.mtime).dos_equals(::Zip::DOSTime.at(entry.mtime)))
+        assert(::Zip::DOSTime.at(file.mtime) == ::Zip::DOSTime.at(entry.mtime))
       end
     end
   end


### PR DESCRIPTION
Having a specific 'does this instance equal another instance' method is kind of annoying and breaks a number of things. Most obviously it breaks comparing to `nil`: `nil.dos_equals(other)` will fail where `nil == other` does not.

So this commit overrides `<=>` in `Zip::DOSTime` and deprecates `dos_equals`.

It should fix #216 in the process...