### PR TITLE
Fix depreciation warning: abstract_output_stream_test.rb:60: warning: `$,' is deprecated

### DIFF
--- a/lib/zip/ioextras/abstract_output_stream.rb
+++ b/lib/zip/ioextras/abstract_output_stream.rb
@@ -11,7 +11,7 @@ module Zip
       end
 
       def print(*params)
-        self << params.join($OUTPUT_FIELD_SEPARATOR) << $OUTPUT_RECORD_SEPARATOR.to_s
+        self << params.join << $OUTPUT_RECORD_SEPARATOR.to_s
       end
 
       def printf(a_format_string, *params)

--- a/test/ioextras/abstract_output_stream_test.rb
+++ b/test/ioextras/abstract_output_stream_test.rb
@@ -20,12 +20,10 @@ class AbstractOutputStreamTest < MiniTest::Test
   def setup
     @output_stream = TestOutputStream.new
 
-    @save_comma_sep = $OUTPUT_FIELD_SEPARATOR
     @save_output_sep = $OUTPUT_RECORD_SEPARATOR
   end
 
   def teardown
-    $OUTPUT_FIELD_SEPARATOR = @save_comma_sep
     $OUTPUT_RECORD_SEPARATOR = @save_output_sep
   end
 
@@ -57,7 +55,6 @@ class AbstractOutputStreamTest < MiniTest::Test
     @output_stream.print('I sure hope so!')
     assert_equal("hello world. You ok out there?\nI sure hope so!\n", @output_stream.buffer)
 
-    $OUTPUT_FIELD_SEPARATOR = nil
     @output_stream.buffer = ''
     @output_stream.print('monkey', 'duck', 'zebra')
     assert_equal("monkeyduckzebra\n", @output_stream.buffer)

--- a/test/ioextras/abstract_output_stream_test.rb
+++ b/test/ioextras/abstract_output_stream_test.rb
@@ -26,7 +26,7 @@ class AbstractOutputStreamTest < MiniTest::Test
 
   def teardown
     $OUTPUT_FIELD_SEPARATOR = @save_comma_sep
-    $\ = @save_output_sep
+    $OUTPUT_RECORD_SEPARATOR = @save_output_sep
   end
 
   def test_write
@@ -40,7 +40,7 @@ class AbstractOutputStreamTest < MiniTest::Test
   end
 
   def test_print
-    $\ = nil # record separator set to nil
+    $OUTPUT_RECORD_SEPARATOR = nil # record separator set to nil
     @output_stream.print('hello')
     assert_equal('hello', @output_stream.buffer)
 
@@ -50,7 +50,7 @@ class AbstractOutputStreamTest < MiniTest::Test
     @output_stream.print(' You ok ', 'out ', 'there?')
     assert_equal('hello world. You ok out there?', @output_stream.buffer)
 
-    $\ = "\n"
+    $OUTPUT_RECORD_SEPARATOR = "\n"
     @output_stream.print
     assert_equal("hello world. You ok out there?\n", @output_stream.buffer)
 
@@ -62,7 +62,7 @@ class AbstractOutputStreamTest < MiniTest::Test
     @output_stream.print('monkey', 'duck', 'zebra')
     assert_equal("monkeyXduckXzebra\n", @output_stream.buffer)
 
-    $\ = nil
+    $OUTPUT_RECORD_SEPARATOR = nil
     @output_stream.buffer = ''
     @output_stream.print(20)
     assert_equal('20', @output_stream.buffer)

--- a/test/ioextras/abstract_output_stream_test.rb
+++ b/test/ioextras/abstract_output_stream_test.rb
@@ -57,10 +57,10 @@ class AbstractOutputStreamTest < MiniTest::Test
     @output_stream.print('I sure hope so!')
     assert_equal("hello world. You ok out there?\nI sure hope so!\n", @output_stream.buffer)
 
-    $OUTPUT_FIELD_SEPARATOR = '\n'
+    $OUTPUT_FIELD_SEPARATOR = nil
     @output_stream.buffer = ''
     @output_stream.print('monkey', 'duck', 'zebra')
-    assert_equal("monkeyXduckXzebra\n", @output_stream.buffer)
+    assert_equal("monkeyduckzebra\n", @output_stream.buffer)
 
     $OUTPUT_RECORD_SEPARATOR = nil
     @output_stream.buffer = ''

--- a/test/ioextras/abstract_output_stream_test.rb
+++ b/test/ioextras/abstract_output_stream_test.rb
@@ -25,7 +25,7 @@ class AbstractOutputStreamTest < MiniTest::Test
   end
 
   def teardown
-    $, = @save_comma_sep
+    $OUTPUT_FIELD_SEPARATOR = @save_comma_sep
     $\ = @save_output_sep
   end
 
@@ -57,7 +57,7 @@ class AbstractOutputStreamTest < MiniTest::Test
     @output_stream.print('I sure hope so!')
     assert_equal("hello world. You ok out there?\nI sure hope so!\n", @output_stream.buffer)
 
-    $, = 'X'
+    $OUTPUT_FIELD_SEPARATOR = '\n'
     @output_stream.buffer = ''
     @output_stream.print('monkey', 'duck', 'zebra')
     assert_equal("monkeyXduckXzebra\n", @output_stream.buffer)


### PR DESCRIPTION
Hello rubyzip community! 👋 

I was thinking about making a small contribution in another area, so I went to run the test suite and noticed this deprecation warning: `abstract_output_stream_test.rb:60: warning: '$,' is deprecated`.

I learned that setting `$,` (aka `$OUTPUT_FIELD_SEPERATOR`) to a non-nil value is now deprecated. This was discussed in https://bugs.ruby-lang.org/issues/14240 and implemented in ruby/ruby@6298ec2.

As a result, I've modified both some test code and application code to assume a world in which this value is always `nil`. 

Since I'm new to this community, and this code [was originally almost 20 years ago(!)](https://github.com/rubyzip/rubyzip/commit/441dcb964393fcb43a4a507f8ff6402cf93ed8fb#diff-859f6edc8864e2e7b8ed6fad65231c59c3f648cc645f1d2ee81f73ca58f49d6fR401), perhaps we should leave it as is until forced to do otherwise?

Anyway, just a little contribution that I hope is found helpful. Let me know if a CHANGELOG entry would be expected for a change this small.