### PR TITLE
Remove compare_enumerables from test_helper.rb

### DIFF
--- a/test/central_directory_test.rb
+++ b/test/central_directory_test.rb
@@ -10,9 +10,7 @@ class ZipCentralDirectoryTest < MiniTest::Test
       cdir = ::Zip::CentralDirectory.read_from_stream(zip_file)
 
       assert_equal(TestZipFile::TEST_ZIP2.entry_names.size, cdir.size)
-      assert(cdir.entries.sort.compare_enumerables(TestZipFile::TEST_ZIP2.entry_names.sort) do |cdir_entry, test_entry_name|
-        cdir_entry.name == test_entry_name
-      end)
+      assert_equal(cdir.entries.map(&:name).sort, TestZipFile::TEST_ZIP2.entry_names.sort)
       assert_equal(TestZipFile::TEST_ZIP2.comment, cdir.comment)
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -165,16 +165,6 @@ module CrcTest
   end
 end
 
-module Enumerable
-  def compare_enumerables(enumerable)
-    array = enumerable.to_a
-    each_with_index do |element, index|
-      return false unless yield(element, array[index])
-    end
-    size == array.size
-  end
-end
-
 module CommonZipFileFixture
   include AssertEntry
 


### PR DESCRIPTION
This change has several benefits:
* When errors occur, the test provides useful feedback, showing you
  expected vs. actual.
* We no longer need to open and modify the Enumerable module.
* The test is more readable.