### PR TITLE
Fix restore options consistency.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # 3.0.0 (Next)
 
+- Fix restore options consistency. [#486](https://github.com/rubyzip/rubyzip/pull/486)
+- View and/or preserve original date created, date modified? (Windows). [#336](https://github.com/rubyzip/rubyzip/issues/336)
 - Fix frozen string literal error. [#475](https://github.com/rubyzip/rubyzip/pull/475)
 - Set the default `Entry` time to the file's mtime on Windows. [#465](https://github.com/rubyzip/rubyzip/issues/465)
 - Ensure that `Entry#time=` sets times as `DOSTime` objects. [#481](https://github.com/rubyzip/rubyzip/issues/481)

--- a/lib/zip.rb
+++ b/lib/zip.rb
@@ -48,6 +48,12 @@ module Zip
                 :force_entry_names_encoding,
                 :validate_entry_sizes
 
+  DEFAULT_RESTORE_OPTIONS = {
+    restore_ownership:   false,
+    restore_permissions: false,
+    restore_times:       false
+  }.freeze
+
   def reset!
     @_ran_once = false
     @unicode_names = false

--- a/lib/zip.rb
+++ b/lib/zip.rb
@@ -50,8 +50,8 @@ module Zip
 
   DEFAULT_RESTORE_OPTIONS = {
     restore_ownership:   false,
-    restore_permissions: false,
-    restore_times:       false
+    restore_permissions: true,
+    restore_times:       true
   }.freeze
 
   def reset!

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -462,11 +462,6 @@ module Zip
       unix_perms_mask = 0o7777 if @restore_ownership
       ::FileUtils.chmod(@unix_perms & unix_perms_mask, dest_path) if @restore_permissions && @unix_perms
       ::FileUtils.chown(@unix_uid, @unix_gid, dest_path) if @restore_ownership && @unix_uid && @unix_gid && ::Process.egid == 0
-
-      # Restore the timestamp on a file. This will either have come from the
-      # original source file that was copied into the archive, or from the
-      # creation date of the archive if there was no original source file.
-      ::FileUtils.touch(dest_path, mtime: time) if @restore_times
     end
 
     def set_extra_attributes_on_path(dest_path) # :nodoc:
@@ -476,6 +471,11 @@ module Zip
       when ::Zip::FSTYPE_UNIX
         set_unix_attributes_on_path(dest_path)
       end
+
+      # Restore the timestamp on a file. This will either have come from the
+      # original source file that was copied into the archive, or from the
+      # creation date of the archive if there was no original source file.
+      ::FileUtils.touch(dest_path, mtime: time) if @restore_times
     end
 
     def pack_c_dir_entry

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -42,9 +42,9 @@ module Zip
       end
       @follow_symlinks = false
 
-      @restore_times       = false
-      @restore_permissions = false
-      @restore_ownership   = false
+      @restore_times       = DEFAULT_RESTORE_OPTIONS[:restore_times]
+      @restore_permissions = DEFAULT_RESTORE_OPTIONS[:restore_permissions]
+      @restore_ownership   = DEFAULT_RESTORE_OPTIONS[:restore_ownership]
       # BUG: need an extra field to support uid/gid's
       @unix_uid            = nil
       @unix_gid            = nil

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -58,10 +58,10 @@ module Zip
     # default -> false.
     attr_accessor :restore_ownership
 
-    # default -> false, but will be set to true in a future version.
+    # default -> true.
     attr_accessor :restore_permissions
 
-    # default -> false, but will be set to true in a future version.
+    # default -> true.
     attr_accessor :restore_times
 
     # Returns the zip files comment, if it has one

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -53,12 +53,6 @@ module Zip
     DATA_BUFFER_SIZE     = 8192
     IO_METHODS           = [:tell, :seek, :read, :eof, :close].freeze
 
-    DEFAULT_OPTIONS = {
-      restore_ownership:   false,
-      restore_permissions: false,
-      restore_times:       false
-    }.freeze
-
     attr_reader :name
 
     # default -> false.
@@ -77,7 +71,7 @@ module Zip
     # a new archive if it doesn't exist already.
     def initialize(path_or_io, create = false, buffer = false, options = {})
       super()
-      options  = DEFAULT_OPTIONS
+      options  = DEFAULT_RESTORE_OPTIONS
                  .merge(compression_level: ::Zip.default_compression)
                  .merge(options)
       @name    = path_or_io.respond_to?(:path) ? path_or_io.path : path_or_io

--- a/test/file_options_test.rb
+++ b/test/file_options_test.rb
@@ -107,10 +107,6 @@ class FileOptionsTest < MiniTest::Test
       zip.extract(ENTRY_2, EXTPATH_2)
     end
 
-    # this test is disabled on Windows for now, waiting for #486.
-    # please remove this after merging #486.
-    skip if Zip::RUNNING_ON_WINDOWS
-
     assert_time_equal(::File.mtime(TXTPATH), ::File.mtime(EXTPATH_1))
     assert_time_equal(::File.mtime(TXTPATH), ::File.mtime(EXTPATH_2))
   end

--- a/test/file_options_test.rb
+++ b/test/file_options_test.rb
@@ -66,7 +66,7 @@ class FileOptionsTest < MiniTest::Test
       zip.extract(ENTRY_3, EXTPATH_3)
     end
 
-    default_perms = 0o100_666 - ::File.umask
+    default_perms = (Zip::RUNNING_ON_WINDOWS ? 0o100_644 : 0o100_666) - ::File.umask
     assert_equal(default_perms, ::File.stat(EXTPATH_1).mode)
     assert_equal(default_perms, ::File.stat(EXTPATH_2).mode)
     assert_equal(default_perms, ::File.stat(EXTPATH_3).mode)


### PR DESCRIPTION
This PR is, finally, to finish off the work to fix and make consistent the options to restore file timestamps and file permissions on extraction.

The default options are now specified at the top level so that both `File` and `Entry` get a consistent view of them. They can still be overridden per-`File` - and per-`Entry` if needs be.

Additionally this PR enables timestamps to be restored on Windows.

This PR closes #422 and fixes #336.