### PR TITLE
Move to use named parameters for some classes (Entry already done)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -109,7 +109,6 @@ Style/NumericPredicate:
 # AllowedMethods: respond_to_missing?
 Style/OptionalBooleanParameter:
   Exclude:
-    - 'lib/zip/entry.rb'
     - 'lib/zip/file.rb'
     - 'lib/zip/file_split.rb'
     - 'lib/zip/output_stream.rb'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -111,7 +111,6 @@ Style/OptionalBooleanParameter:
   Exclude:
     - 'lib/zip/file.rb'
     - 'lib/zip/file_split.rb'
-    - 'lib/zip/output_stream.rb'
 
 # Offense count: 17
 # Cop supports --auto-correct.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -104,13 +104,6 @@ Style/NumericPredicate:
     - 'lib/zip/ioextras.rb'
     - 'lib/zip/ioextras/abstract_input_stream.rb'
 
-# Offense count: 1
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: respond_to_missing?
-Style/OptionalBooleanParameter:
-  Exclude:
-    - 'lib/zip/file_split.rb'
-
 # Offense count: 17
 # Cop supports --auto-correct.
 # Configuration parameters: ConvertCodeThatCanStartToReturnNil, AllowedMethods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -104,12 +104,11 @@ Style/NumericPredicate:
     - 'lib/zip/ioextras.rb'
     - 'lib/zip/ioextras/abstract_input_stream.rb'
 
-# Offense count: 6
+# Offense count: 1
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: respond_to_missing?
 Style/OptionalBooleanParameter:
   Exclude:
-    - 'lib/zip/file.rb'
     - 'lib/zip/file_split.rb'
 
 # Offense count: 17

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # 3.0.0 (Next)
 
+- Use named parameters for optional arguments in the public API.
 - Raise an error if entry names exceed 65,535 characters. [#247](https://github.com/rubyzip/rubyzip/issues/247)
 - Remove the `ZipXError` v1 legacy classes.
 - Raise an error on reading a split archive with `InputStream`. [#349](https://github.com/rubyzip/rubyzip/issues/349)

--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ Any attempt to move about in a zip file opened with `Zip::InputStream` could res
 Rubyzip supports reading/writing zip files with traditional zip encryption (a.k.a. "ZipCrypto"). AES encryption is not yet supported. It can be used with buffer streams, e.g.:
 
 ```ruby
-Zip::OutputStream.write_buffer(::StringIO.new(''), Zip::TraditionalEncrypter.new('password')) do |out|
+Zip::OutputStream.write_buffer(
+  ::StringIO.new, encrypter: Zip::TraditionalEncrypter.new('password')
+) do |out|
   out.put_next_entry("my_file.txt")
   out.write my_data
 end.string

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ input_filenames = ['image.jpg', 'description.txt', 'stats.csv']
 
 zipfile_name = "/Users/me/Desktop/archive.zip"
 
-Zip::File.open(zipfile_name, Zip::File::CREATE) do |zipfile|
+Zip::File.open(zipfile_name, create: true) do |zipfile|
   input_filenames.each do |filename|
     # Two arguments:
     # - The name of the file as it will appear in the archive
@@ -89,7 +89,7 @@ class ZipFileGenerator
   def write
     entries = Dir.entries(@input_dir) - %w[. ..]
 
-    ::Zip::File.open(@output_file, ::Zip::File::CREATE) do |zipfile|
+    ::Zip::File.open(@output_file, create: true) do |zipfile|
       write_entries entries, '', zipfile
     end
   end
@@ -318,7 +318,7 @@ Where X is an integer between 0 and 9, inclusive. If this option is set to 0 (`Z
 This can also be set for each archive as an option to `Zip::File`:
 
 ```ruby
-Zip::File.open('foo.zip', Zip::File::CREATE, {compression_level: 9}) do |zip|
+Zip::File.open('foo.zip', create:true, compression_level: 9) do |zip|
   zip.add ...
 end
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,17 @@
 
 Rubyzip is a ruby library for reading and writing zip files.
 
-## Important note
+## Important notes
+
+### Version 3.0
+
+The public API of some classes has been modernized to use named parameters for optional arguments. Please check your usage of the following Rubyzip classes:
+* `File`
+* `Entry`
+* `InputStream`
+* `OutputStream`
+
+### Older versions (pre 2.0)
 
 The Rubyzip interface has changed!!! No need to do `require "zip/zip"` and `Zip` prefix in class names removed.
 

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -333,7 +333,7 @@ module Zip
        @extra ? @extra.local_size : 0].pack('VvvvvvVVVvv')
     end
 
-    def write_local_entry(io, rewrite = false) #:nodoc:all
+    def write_local_entry(io, rewrite: false) #:nodoc:all
       prep_zip64_extra(true)
       verify_local_header_size! if rewrite
       @local_header_offset = io.tell

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -577,7 +577,7 @@ module Zip
           raise "unknown @file_type #{@ftype}"
         end
       else
-        zis = ::Zip::InputStream.new(@zipfile, local_header_offset)
+        zis = ::Zip::InputStream.new(@zipfile, offset: local_header_offset)
         zis.instance_variable_set(:@complete_entry, self)
         zis.get_next_entry
         if block

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -128,7 +128,7 @@ module Zip
 
       # Same as #open. But outputs data to a buffer instead of a file
       def add_buffer
-        io = ::StringIO.new(+'')
+        io = ::StringIO.new
         zf = ::Zip::File.new(io, true, true)
         yield zf
         zf.write_buffer(io)
@@ -297,7 +297,7 @@ module Zip
     end
 
     # Write buffer write changes to buffer and return
-    def write_buffer(io = ::StringIO.new(''))
+    def write_buffer(io = ::StringIO.new)
       ::Zip::OutputStream.write_buffer(io) do |zos|
         @entry_set.each { |e| e.write_to_zip_output_stream(zos) }
         zos.comment = comment

--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -185,10 +185,10 @@ module Zip
     # specified. If a block is passed the stream object is passed to the block and
     # the stream is automatically closed afterwards just as with ruby's builtin
     # File.open method.
-    def get_output_stream(entry, permission_int = nil, comment = nil,
-                          extra = nil, compressed_size = nil, crc = nil,
-                          compression_method = nil, compression_level = nil,
-                          size = nil, time = nil, &a_proc)
+    def get_output_stream(entry, permissions: nil, comment: nil,
+                          extra: nil, compressed_size: nil, crc: nil,
+                          compression_method: nil, compression_level: nil,
+                          size: nil, time: nil, &a_proc)
 
       new_entry =
         if entry.kind_of?(Entry)
@@ -205,7 +205,7 @@ module Zip
         raise ArgumentError,
               "cannot open stream to directory entry - '#{new_entry}'"
       end
-      new_entry.unix_perms = permission_int
+      new_entry.unix_perms = permissions
       zip_streamable_entry = StreamableStream.new(new_entry)
       @entry_set << zip_streamable_entry
       zip_streamable_entry.get_output_stream(&a_proc)

--- a/lib/zip/file_split.rb
+++ b/lib/zip/file_split.rb
@@ -67,8 +67,8 @@ module Zip
 
     # Splits an archive into parts with segment size
     def split(
-      zip_file_name, segment_size = MAX_SEGMENT_SIZE,
-      delete_zip_file = true, partial_zip_file_name = nil
+      zip_file_name, segment_size: MAX_SEGMENT_SIZE,
+      delete_original: true, partial_zip_file_name: nil
     )
       raise Error, "File #{zip_file_name} not found" unless ::File.exist?(zip_file_name)
       raise Errno::ENOENT, zip_file_name unless ::File.readable?(zip_file_name)
@@ -90,7 +90,7 @@ module Zip
           )
         end
       end
-      ::File.delete(zip_file_name) if delete_zip_file
+      ::File.delete(zip_file_name) if delete_original
       szip_file_index
     end
   end

--- a/lib/zip/filesystem.rb
+++ b/lib/zip/filesystem.rb
@@ -21,7 +21,7 @@ module Zip
   #
   #   require 'zip/filesystem'
   #
-  #   Zip::File.open("my.zip", Zip::File::CREATE) {
+  #   Zip::File.open("my.zip", create: true) {
   #     |zipfile|
   #     zipfile.file.open("first.txt", "w") { |f| f.puts "Hello world" }
   #     zipfile.dir.mkdir("mydir")

--- a/lib/zip/filesystem/zip_file_name_mapper.rb
+++ b/lib/zip/filesystem/zip_file_name_mapper.rb
@@ -28,7 +28,7 @@ module Zip
 
       def get_output_stream(filename, permissions = nil, &a_proc)
         @zip_file.get_output_stream(
-          expand_to_entry(filename), permissions, &a_proc
+          expand_to_entry(filename), permissions: permissions, &a_proc
         )
       end
 

--- a/lib/zip/input_stream.rb
+++ b/lib/zip/input_stream.rb
@@ -51,7 +51,7 @@ module Zip
     #
     # @param context [String||IO||StringIO] file path or IO/StringIO object
     # @param offset [Integer] offset in the IO/StringIO
-    def initialize(context, offset = 0, decrypter = nil)
+    def initialize(context, offset: 0, decrypter: nil)
       super()
       @archive_io = get_io(context, offset)
       @decompressor = ::Zip::NullDecompressor
@@ -99,8 +99,8 @@ module Zip
       # Same as #initialize but if a block is passed the opened
       # stream is passed to the block and closed when the block
       # returns.
-      def open(filename_or_io, offset = 0, decrypter = nil)
-        zio = new(filename_or_io, offset, decrypter)
+      def open(filename_or_io, offset: 0, decrypter: nil)
+        zio = new(filename_or_io, offset: offset, decrypter: decrypter)
         return zio unless block_given?
 
         begin
@@ -110,9 +110,9 @@ module Zip
         end
       end
 
-      def open_buffer(filename_or_io, offset = 0)
+      def open_buffer(filename_or_io, offset: 0)
         warn 'open_buffer is deprecated!!! Use open instead!'
-        ::Zip::InputStream.open(filename_or_io, offset)
+        ::Zip::InputStream.open(filename_or_io, offset: offset)
       end
     end
 

--- a/lib/zip/output_stream.rb
+++ b/lib/zip/output_stream.rb
@@ -59,7 +59,7 @@ module Zip
       end
 
       # Same as #open but writes to a filestream instead
-      def write_buffer(io = ::StringIO.new(''), encrypter: nil)
+      def write_buffer(io = ::StringIO.new, encrypter: nil)
         io.binmode if io.respond_to?(:binmode)
         zos = new(io, stream: true, encrypter: encrypter)
         yield zos

--- a/lib/zip/output_stream.rb
+++ b/lib/zip/output_stream.rb
@@ -26,7 +26,7 @@ module Zip
 
     # Opens the indicated zip file. If a file with that name already
     # exists it will be overwritten.
-    def initialize(file_name, stream = false, encrypter = nil)
+    def initialize(file_name, stream: false, encrypter: nil)
       super()
       @file_name = file_name
       @output_stream = if stream
@@ -52,7 +52,7 @@ module Zip
       def open(file_name, encrypter = nil)
         return new(file_name) unless block_given?
 
-        zos = new(file_name, false, encrypter)
+        zos = new(file_name, stream: false, encrypter: encrypter)
         yield zos
       ensure
         zos.close if zos
@@ -61,7 +61,7 @@ module Zip
       # Same as #open but writes to a filestream instead
       def write_buffer(io = ::StringIO.new(''), encrypter = nil)
         io.binmode if io.respond_to?(:binmode)
-        zos = new(io, true, encrypter)
+        zos = new(io, stream: true, encrypter: encrypter)
         yield zos
         zos.close_buffer
       end

--- a/lib/zip/output_stream.rb
+++ b/lib/zip/output_stream.rb
@@ -49,7 +49,7 @@ module Zip
     # stream is passed to the block and closed when the block
     # returns.
     class << self
-      def open(file_name, encrypter = nil)
+      def open(file_name, encrypter: nil)
         return new(file_name) unless block_given?
 
         zos = new(file_name, stream: false, encrypter: encrypter)
@@ -59,7 +59,7 @@ module Zip
       end
 
       # Same as #open but writes to a filestream instead
-      def write_buffer(io = ::StringIO.new(''), encrypter = nil)
+      def write_buffer(io = ::StringIO.new(''), encrypter: nil)
         io.binmode if io.respond_to?(:binmode)
         zos = new(io, stream: true, encrypter: encrypter)
         yield zos

--- a/lib/zip/output_stream.rb
+++ b/lib/zip/output_stream.rb
@@ -177,7 +177,7 @@ module Zip
       pos = @output_stream.pos
       @entry_set.each do |entry|
         @output_stream.pos = entry.local_header_offset
-        entry.write_local_entry(@output_stream, true)
+        entry.write_local_entry(@output_stream, rewrite: true)
       end
       @output_stream.pos = pos
     end

--- a/samples/example_filesystem.rb
+++ b/samples/example_filesystem.rb
@@ -9,7 +9,7 @@ EXAMPLE_ZIP = 'filesystem.zip'
 
 File.delete(EXAMPLE_ZIP) if File.exist?(EXAMPLE_ZIP)
 
-Zip::File.open(EXAMPLE_ZIP, Zip::File::CREATE) do |zf|
+Zip::File.open(EXAMPLE_ZIP, create: true) do |zf|
   zf.file.open('file1.txt', 'w') { |os| os.write 'first file1.txt' }
   zf.dir.mkdir('dir1')
   zf.dir.chdir('dir1')

--- a/samples/example_recursive.rb
+++ b/samples/example_recursive.rb
@@ -23,7 +23,7 @@ class ZipFileGenerator
   def write
     entries = Dir.entries(@input_dir) - %w[. ..]
 
-    ::Zip::File.open(@output_file, ::Zip::File::CREATE) do |zipfile|
+    ::Zip::File.open(@output_file, create: true) do |zipfile|
       write_entries entries, '', zipfile
     end
   end

--- a/test/case_sensitivity_test.rb
+++ b/test/case_sensitivity_test.rb
@@ -19,7 +19,7 @@ class ZipCaseSensitivityTest < MiniTest::Test
     ::Zip.case_insensitive_match = false
 
     SRC_FILES.each { |fn, _en| assert(::File.exist?(fn)) }
-    zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
+    zf = ::Zip::File.new(EMPTY_FILENAME, create: true)
 
     SRC_FILES.each { |fn, en| zf.add(en, fn) }
     zf.close
@@ -38,7 +38,7 @@ class ZipCaseSensitivityTest < MiniTest::Test
     ::Zip.case_insensitive_match = true
 
     SRC_FILES.each { |fn, _en| assert(::File.exist?(fn)) }
-    zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
+    zf = ::Zip::File.new(EMPTY_FILENAME, create: true)
 
     assert_raises Zip::EntryExistsError do
       SRC_FILES.each { |fn, en| zf.add(en, fn) }
@@ -50,7 +50,7 @@ class ZipCaseSensitivityTest < MiniTest::Test
     ::Zip.case_insensitive_match = false
 
     SRC_FILES.each { |fn, _en| assert(::File.exist?(fn)) }
-    zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
+    zf = ::Zip::File.new(EMPTY_FILENAME, create: true)
 
     SRC_FILES.each { |fn, en| zf.add(en, fn) }
     zf.close

--- a/test/encryption_test.rb
+++ b/test/encryption_test.rb
@@ -20,7 +20,10 @@ class EncryptionTest < MiniTest::Test
 
     password = 'swordfish'
 
-    encrypted_zip = Zip::OutputStream.write_buffer(::StringIO.new(+''), Zip::TraditionalEncrypter.new(password)) do |out|
+    encrypted_zip = Zip::OutputStream.write_buffer(
+      ::StringIO.new(+''),
+      encrypter: Zip::TraditionalEncrypter.new(password)
+    ) do |out|
       out.put_next_entry(test_filename)
       out.write content
     end

--- a/test/encryption_test.rb
+++ b/test/encryption_test.rb
@@ -28,7 +28,9 @@ class EncryptionTest < MiniTest::Test
       out.write content
     end
 
-    Zip::InputStream.open(encrypted_zip, 0, Zip::TraditionalDecrypter.new(password)) do |zis|
+    Zip::InputStream.open(
+      encrypted_zip, decrypter: Zip::TraditionalDecrypter.new(password)
+    ) do |zis|
       entry = zis.get_next_entry
       assert_equal test_filename, entry.name
       assert_equal 1327, entry.size
@@ -36,7 +38,10 @@ class EncryptionTest < MiniTest::Test
     end
 
     assert_raises(Zip::DecompressionError) do
-      Zip::InputStream.open(encrypted_zip, 0, Zip::TraditionalDecrypter.new("#{password}wrong")) do |zis|
+      Zip::InputStream.open(
+        encrypted_zip,
+        decrypter: Zip::TraditionalDecrypter.new("#{password}wrong")
+      ) do |zis|
         zis.get_next_entry
         assert_equal content, zis.read
       end
@@ -44,7 +49,10 @@ class EncryptionTest < MiniTest::Test
   end
 
   def test_decrypt
-    Zip::InputStream.open(ENCRYPT_ZIP_TEST_FILE, 0, Zip::TraditionalDecrypter.new('password')) do |zis|
+    Zip::InputStream.open(
+      ENCRYPT_ZIP_TEST_FILE,
+      decrypter: Zip::TraditionalDecrypter.new('password')
+    ) do |zis|
       entry = zis.get_next_entry
       assert_equal 'file1.txt', entry.name
       assert_equal 1327, entry.size

--- a/test/encryption_test.rb
+++ b/test/encryption_test.rb
@@ -21,7 +21,7 @@ class EncryptionTest < MiniTest::Test
     password = 'swordfish'
 
     encrypted_zip = Zip::OutputStream.write_buffer(
-      ::StringIO.new(+''),
+      ::StringIO.new,
       encrypter: Zip::TraditionalEncrypter.new(password)
     ) do |out|
       out.put_next_entry(test_filename)

--- a/test/entry_test.rb
+++ b/test/entry_test.rb
@@ -167,7 +167,7 @@ class ZipEntryTest < MiniTest::Test
         z.write_zip64_support = false
       end
 
-      zipfile = Zip::File.open(tmp_zip, Zip::File::CREATE)
+      zipfile = Zip::File.open(tmp_zip, create: true)
 
       mimetype_entry = Zip::Entry.new(
         zipfile,                # @zipfile

--- a/test/file_extract_test.rb
+++ b/test/file_extract_test.rb
@@ -99,7 +99,7 @@ class ZipFileExtractTest < MiniTest::Test
       true_size = 500_000
       fake_size = 1
 
-      ::Zip::File.open(real_zip, ::Zip::File::CREATE) do |zf|
+      ::Zip::File.open(real_zip, create: true) do |zf|
         zf.get_output_stream(file_name) do |os|
           os.write 'a' * true_size
         end

--- a/test/file_options_test.rb
+++ b/test/file_options_test.rb
@@ -30,13 +30,13 @@ class FileOptionsTest < MiniTest::Test
     ::FileUtils.cp(TXTPATH, TXTPATH_755)
     ::File.chmod(0o755, TXTPATH_755)
 
-    ::Zip::File.open(ZIPPATH, true) do |zip|
+    ::Zip::File.open(ZIPPATH, create: true) do |zip|
       zip.add(ENTRY_1, TXTPATH)
       zip.add(ENTRY_2, TXTPATH_600)
       zip.add(ENTRY_3, TXTPATH_755)
     end
 
-    ::Zip::File.open(ZIPPATH, false, restore_permissions: true) do |zip|
+    ::Zip::File.open(ZIPPATH, restore_permissions: true) do |zip|
       zip.extract(ENTRY_1, EXTPATH_1)
       zip.extract(ENTRY_2, EXTPATH_2)
       zip.extract(ENTRY_3, EXTPATH_3)
@@ -54,13 +54,13 @@ class FileOptionsTest < MiniTest::Test
     ::FileUtils.cp(TXTPATH, TXTPATH_755)
     ::File.chmod(0o755, TXTPATH_755)
 
-    ::Zip::File.open(ZIPPATH, true) do |zip|
+    ::Zip::File.open(ZIPPATH, create: true) do |zip|
       zip.add(ENTRY_1, TXTPATH)
       zip.add(ENTRY_2, TXTPATH_600)
       zip.add(ENTRY_3, TXTPATH_755)
     end
 
-    ::Zip::File.open(ZIPPATH, false, restore_permissions: false) do |zip|
+    ::Zip::File.open(ZIPPATH, restore_permissions: false) do |zip|
       zip.extract(ENTRY_1, EXTPATH_1)
       zip.extract(ENTRY_2, EXTPATH_2)
       zip.extract(ENTRY_3, EXTPATH_3)
@@ -79,7 +79,7 @@ class FileOptionsTest < MiniTest::Test
     ::FileUtils.cp(TXTPATH, TXTPATH_755)
     ::File.chmod(0o755, TXTPATH_755)
 
-    ::Zip::File.open(ZIPPATH, true) do |zip|
+    ::Zip::File.open(ZIPPATH, create: true) do |zip|
       zip.add(ENTRY_1, TXTPATH)
       zip.add(ENTRY_2, TXTPATH_600)
       zip.add(ENTRY_3, TXTPATH_755)
@@ -97,12 +97,12 @@ class FileOptionsTest < MiniTest::Test
   end
 
   def test_restore_times_true
-    ::Zip::File.open(ZIPPATH, true) do |zip|
+    ::Zip::File.open(ZIPPATH, create: true) do |zip|
       zip.add(ENTRY_1, TXTPATH)
       zip.add_stored(ENTRY_2, TXTPATH)
     end
 
-    ::Zip::File.open(ZIPPATH, false, restore_times: true) do |zip|
+    ::Zip::File.open(ZIPPATH, restore_times: true) do |zip|
       zip.extract(ENTRY_1, EXTPATH_1)
       zip.extract(ENTRY_2, EXTPATH_2)
     end
@@ -112,12 +112,12 @@ class FileOptionsTest < MiniTest::Test
   end
 
   def test_restore_times_false
-    ::Zip::File.open(ZIPPATH, true) do |zip|
+    ::Zip::File.open(ZIPPATH, create: true) do |zip|
       zip.add(ENTRY_1, TXTPATH)
       zip.add_stored(ENTRY_2, TXTPATH)
     end
 
-    ::Zip::File.open(ZIPPATH, false, restore_times: false) do |zip|
+    ::Zip::File.open(ZIPPATH, restore_times: false) do |zip|
       zip.extract(ENTRY_1, EXTPATH_1)
       zip.extract(ENTRY_2, EXTPATH_2)
     end
@@ -127,7 +127,7 @@ class FileOptionsTest < MiniTest::Test
   end
 
   def test_restore_times_true_as_default
-    ::Zip::File.open(ZIPPATH, true) do |zip|
+    ::Zip::File.open(ZIPPATH, create: true) do |zip|
       zip.add(ENTRY_1, TXTPATH)
       zip.add_stored(ENTRY_2, TXTPATH)
     end

--- a/test/file_permissions_test.rb
+++ b/test/file_permissions_test.rb
@@ -48,7 +48,7 @@ class FilePermissionsTest < MiniTest::Test
   end
 
   def create_files
-    ::Zip::File.open(ZIPNAME, ::Zip::File::CREATE) do |zip|
+    ::Zip::File.open(ZIPNAME, create: true) do |zip|
       zip.comment = 'test'
     end
 

--- a/test/file_split_test.rb
+++ b/test/file_split_test.rb
@@ -27,7 +27,9 @@ class ZipFileSplitTest < MiniTest::Test
   end
 
   def test_split
-    result = ::Zip::File.split(TEST_ZIP.zip_name, 65_536, false)
+    result = ::Zip::File.split(
+      TEST_ZIP.zip_name, segment_size: 65_536, delete_original: false
+    )
 
     return if result.nil?
 

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -32,21 +32,7 @@ class ZipFileTest < MiniTest::Test
   def test_create_from_scratch
     comment = 'a short comment'
 
-    zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
-    zf.get_output_stream('myFile') { |os| os.write 'myFile contains just this' }
-    zf.mkdir('dir1')
-    zf.comment = comment
-    zf.close
-
-    zf_read = ::Zip::File.new(EMPTY_FILENAME)
-    assert_equal(comment, zf_read.comment)
-    assert_equal(2, zf_read.entries.length)
-  end
-
-  def test_create_from_scratch_with_old_create_parameter
-    comment = 'a short comment'
-
-    zf = ::Zip::File.new(EMPTY_FILENAME, 1)
+    zf = ::Zip::File.new(EMPTY_FILENAME, create: true)
     zf.get_output_stream('myFile') { |os| os.write 'myFile contains just this' }
     zf.mkdir('dir1')
     zf.comment = comment
@@ -184,7 +170,7 @@ class ZipFileTest < MiniTest::Test
   end
 
   def test_cleans_up_tempfiles_after_close
-    zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
+    zf = ::Zip::File.new(EMPTY_FILENAME, create: true)
     zf.get_output_stream('myFile') do |os|
       @tempfile_path = os.path
       os.write 'myFile contains just this'
@@ -208,9 +194,7 @@ class ZipFileTest < MiniTest::Test
     sizes = []
 
     files.each do |name, comp|
-      zf = ::Zip::File.new(
-        name, ::Zip::File::CREATE, false, { compression_level: comp }
-      )
+      zf = ::Zip::File.new(name, create: true, compression_level: comp)
 
       zf.add(entry_name, src_file)
       zf.close
@@ -243,7 +227,7 @@ class ZipFileTest < MiniTest::Test
 
     files.each do |name, comp|
       ::Zip.default_compression = comp
-      zf = ::Zip::File.new(name, ::Zip::File::CREATE)
+      zf = ::Zip::File.new(name, create: true)
 
       zf.add(entry_name, src_file)
       zf.close
@@ -268,7 +252,7 @@ class ZipFileTest < MiniTest::Test
     src_file = 'test/data/file2.txt'
     entry_name = 'newEntryName.rb'
     assert(::File.exist?(src_file))
-    zf = ::Zip::File.new(EMPTY_FILENAME, ::Zip::File::CREATE)
+    zf = ::Zip::File.new(EMPTY_FILENAME, create: true)
     zf.add_stored(entry_name, src_file)
     zf.close
 
@@ -294,7 +278,7 @@ class ZipFileTest < MiniTest::Test
     ::File.chmod(0o664, src_zip)
     assert_equal(0o100664, ::File.stat(src_zip).mode)
 
-    zf = ::Zip::File.new(src_zip, ::Zip::File::CREATE)
+    zf = ::Zip::File.new(src_zip, create: true)
     zf.add('newEntryName.rb', 'test/data/file2.txt')
     zf.close
 
@@ -385,7 +369,7 @@ class ZipFileTest < MiniTest::Test
     ::File.unlink(zf_name) if ::File.exist?(zf_name)
     arr = []
     arr_renamed = []
-    ::Zip::File.open(zf_name, ::Zip::File::CREATE) do |zf|
+    ::Zip::File.open(zf_name, create: true) do |zf|
       zf.mkdir('test')
       arr << 'test/'
       arr_renamed << 'Ztest/'
@@ -398,7 +382,7 @@ class ZipFileTest < MiniTest::Test
     zf = ::Zip::File.open(zf_name)
     assert_equal(zf.entries.map(&:name), arr)
     zf.close
-    Zip::File.open(zf_name, 'wb') do |z|
+    Zip::File.open(zf_name) do |z|
       z.each do |f|
         z.rename(f, "Z#{f.name}")
       end
@@ -522,7 +506,7 @@ class ZipFileTest < MiniTest::Test
   def test_double_commit(filename = 'test/data/generated/double_commit_test.zip')
     ::FileUtils.touch('test/data/generated/test_double_commit1.txt')
     ::FileUtils.touch('test/data/generated/test_double_commit2.txt')
-    zf = ::Zip::File.open(filename, ::Zip::File::CREATE)
+    zf = ::Zip::File.open(filename, create: true)
     zf.add('test1.txt', 'test/data/generated/test_double_commit1.txt')
     zf.commit
     zf.add('test2.txt', 'test/data/generated/test_double_commit2.txt')
@@ -695,7 +679,7 @@ class ZipFileTest < MiniTest::Test
   def test_streaming
     fname = ::File.join(__dir__, '..', 'README.md')
     zname = 'test/data/generated/README.zip'
-    Zip::File.open(zname, Zip::File::CREATE) do |zipfile|
+    Zip::File.open(zname, create: true) do |zipfile|
       zipfile.get_output_stream(File.basename(fname)) do |f|
         f.puts File.read(fname)
       end

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -545,8 +545,7 @@ class ZipFileTest < MiniTest::Test
     zf = ::Zip::File.new(TEST_ZIP.zip_name)
     old_name = zf.entries.first
     zf.rename(old_name, new_name)
-    io = ::StringIO.new(+'')
-    buffer = zf.write_buffer(io)
+    buffer = zf.write_buffer(::StringIO.new)
     File.open(TEST_ZIP.zip_name, 'wb') { |f| f.write buffer.string }
     zf_read = ::Zip::File.new(TEST_ZIP.zip_name)
     refute_nil(zf_read.entries.detect { |e| e.name == new_name })

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -68,22 +68,30 @@ class ZipFileTest < MiniTest::Test
       assert_equal(count + 1, zf.size)
       assert_equal('Putting stuff in data/generated/empty.txt', zf.read('test/data/generated/empty.txt'))
 
-      custom_entry_args = [
-        TEST_COMMENT, TEST_EXTRA, TEST_COMPRESSED_SIZE, TEST_CRC,
-        ::Zip::Entry::STORED, ::Zlib::BEST_SPEED, TEST_SIZE, TEST_TIME
-      ]
-      zf.get_output_stream('entry_with_custom_args.txt', nil, *custom_entry_args) do |os|
+      custom_entry_args = {
+        comment: TEST_COMMENT, compressed_size: TEST_COMPRESSED_SIZE,
+        crc: TEST_CRC, compression_method: ::Zip::COMPRESSION_METHOD_STORE,
+        compression_level: ::Zlib::BEST_SPEED, size: TEST_SIZE, time: TEST_TIME
+      }
+      zf.get_output_stream(
+        'entry_with_custom_args.txt', **custom_entry_args
+      ) do |os|
         os.write 'Some data'
       end
+
       assert_equal(count + 2, zf.size)
       entry = zf.get_entry('entry_with_custom_args.txt')
-      assert_equal(custom_entry_args[0], entry.comment)
-      assert_equal(custom_entry_args[2], entry.compressed_size)
-      assert_equal(custom_entry_args[3], entry.crc)
-      assert_equal(custom_entry_args[4], entry.compression_method)
-      assert_equal(custom_entry_args[5], entry.compression_level)
-      assert_equal(custom_entry_args[6], entry.size)
-      assert_equal(custom_entry_args[7], entry.time)
+      assert_equal(custom_entry_args[:comment], entry.comment)
+      assert_equal(custom_entry_args[:compressed_size], entry.compressed_size)
+      assert_equal(custom_entry_args[:crc], entry.crc)
+      assert_equal(
+        custom_entry_args[:compression_method], entry.compression_method
+      )
+      assert_equal(
+        custom_entry_args[:compression_level], entry.compression_level
+      )
+      assert_equal(custom_entry_args[:size], entry.size)
+      assert_equal(custom_entry_args[:time], entry.time)
 
       zf.get_output_stream('entry.bin') do |os|
         os.write(::File.open('test/data/generated/5entry.zip', 'rb').read)

--- a/test/local_entry_test.rb
+++ b/test/local_entry_test.rb
@@ -126,7 +126,7 @@ class ZipLocalEntryTest < MiniTest::Test
     buf2 = StringIO.new
     entry.size = 0x123456789ABCDEF0
     entry.compressed_size = 0x0123456789ABCDEF
-    entry.write_local_entry(buf2, true)
+    entry.write_local_entry(buf2, rewrite: true)
     refute_nil(entry.extra['Zip64'])
     refute_equal(buf1.size, 0)
     assert_equal(buf1.size, buf2.size) # it can't grow, or we'd clobber file data

--- a/test/output_stream_test.rb
+++ b/test/output_stream_test.rb
@@ -25,8 +25,7 @@ class ZipOutputStreamTest < MiniTest::Test
   end
 
   def test_write_buffer
-    io = ::StringIO.new(+'')
-    buffer = ::Zip::OutputStream.write_buffer(io) do |zos|
+    buffer = ::Zip::OutputStream.write_buffer(::StringIO.new) do |zos|
       zos.comment = TEST_ZIP.comment
       write_test_zip(zos)
     end
@@ -35,8 +34,7 @@ class ZipOutputStreamTest < MiniTest::Test
   end
 
   def test_write_buffer_binmode
-    io = ::StringIO.new(+'')
-    buffer = ::Zip::OutputStream.write_buffer(io) do |zos|
+    buffer = ::Zip::OutputStream.write_buffer(::StringIO.new) do |zos|
       zos.comment = TEST_ZIP.comment
       write_test_zip(zos)
     end
@@ -70,6 +68,15 @@ class ZipOutputStreamTest < MiniTest::Test
     ::Zip::File.open(tmp_file) # Should open without error.
   ensure
     ::File.unlink(tmp_file)
+  end
+
+  def test_write_buffer_with_default_io
+    buffer = ::Zip::OutputStream.write_buffer do |zos|
+      zos.comment = TEST_ZIP.comment
+      write_test_zip(zos)
+    end
+    File.open(TEST_ZIP.zip_name, 'wb') { |f| f.write buffer.string }
+    assert_test_zip_contents(TEST_ZIP)
   end
 
   def test_writing_to_closed_stream

--- a/test/stored_support_test.rb
+++ b/test/stored_support_test.rb
@@ -22,7 +22,9 @@ class StoredSupportTest < MiniTest::Test
   end
 
   def test_encrypted_read
-    Zip::InputStream.open(ENCRYPTED_STORED_ZIP_TEST_FILE, 0, Zip::TraditionalDecrypter.new('password')) do |zis|
+    Zip::InputStream.open(
+      ENCRYPTED_STORED_ZIP_TEST_FILE, decrypter: Zip::TraditionalDecrypter.new('password')
+    ) do |zis|
       entry = zis.get_next_entry
       assert_equal 'file1.txt', entry.name
       assert_equal 1_327, entry.size

--- a/test/unicode_file_names_and_comments_test.rb
+++ b/test/unicode_file_names_and_comments_test.rb
@@ -53,7 +53,7 @@ class ZipUnicodeFileNamesAndComments < MiniTest::Test
 
   def test_unicode_comment
     str = '渠道升级'
-    ::Zip::File.open(FILENAME, Zip::File::CREATE) do |z|
+    ::Zip::File.open(FILENAME, create: true) do |z|
       z.comment = str
     end
 

--- a/test/zip64_full_test.rb
+++ b/test/zip64_full_test.rb
@@ -31,7 +31,7 @@ class Zip64FullTest < MiniTest::Test
       # Write just over 4GB (stored, so the zip file exceeds 4GB).
       buf = 'blah' * 16_384
       zf.get_output_stream(
-        'huge_file', nil, nil, nil, nil, nil, ::Zip::Entry::STORED
+        'huge_file', compression_method: ::Zip::COMPRESSION_METHOD_STORE
       ) do |io|
         65_537.times { io.write(buf) }
       end

--- a/test/zip64_full_test.rb
+++ b/test/zip64_full_test.rb
@@ -21,7 +21,7 @@ class Zip64FullTest < MiniTest::Test
     last_text = 'this tests files starting after 4GB in the archive'
     comment_text = 'this is a file comment in a zip64 archive'
 
-    ::Zip::File.open(HUGE_ZIP, ::Zip::File::CREATE) do |zf|
+    ::Zip::File.open(HUGE_ZIP, create: true) do |zf|
       zf.comment = comment_text
 
       zf.get_output_stream('first_file.txt') do |io|


### PR DESCRIPTION
This makes sense as named parameters make many things more usable.

It is a breaking change, so now is the right time as we're releasing 3.0 next.