### PR TITLE
Updating readme for password protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Rubyzip supports reading/writing zip files with traditional zip encryption (a.k.
 
 ```ruby
 Zip::OutputStream.write_buffer(
-  ::StringIO.new, encrypter: Zip::TraditionalEncrypter.new('password')
+  ::StringIO.new, Zip::TraditionalEncrypter.new('password')
 ) do |out|
   out.put_next_entry("my_file.txt")
   out.write my_data


### PR DESCRIPTION
Current initialization of `OutputStream` does not use keyword parameters

https://github.com/rubyzip/rubyzip/blob/bc6523ec43e911d7931aafbda2a81dae68617a90/lib/zip/output_stream.rb#L29