### PR TITLE
Fix `OutputStream#put_next_entry` to preserve `StreamableStream`s.

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -83,14 +83,21 @@ module Zip
       @ftype = name_is_directory? ? :directory : :file
 
       @zipfile            = zipfile
-      @comment            = comment
-      @compression_method = compression_method
-      @compression_level  = compression_level
+      @comment            = comment || ''
+      @compression_method = compression_method || DEFLATED
+      @compression_level  = compression_level || ::Zip.default_compression
 
-      @compressed_size    = compressed_size
-      @crc                = crc
-      @size               = size
-      @time               = time
+      @compressed_size    = compressed_size || 0
+      @crc                = crc || 0
+      @size               = size || 0
+      @time               = case time
+                            when ::Zip::DOSTime
+                              time
+                            when Time
+                              ::Zip::DOSTime.from_time(time)
+                            else
+                              ::Zip::DOSTime.now
+                            end
       @extra              =
         extra.kind_of?(ExtraField) ? extra : ExtraField.new(extra.to_s)
 

--- a/lib/zip/output_stream.rb
+++ b/lib/zip/output_stream.rb
@@ -100,15 +100,15 @@ module Zip
     )
       raise Error, 'zip stream is closed' if @closed
 
-      new_entry = if entry_name.kind_of?(Entry)
-                    entry_name
-                  else
-                    Entry.new(
-                      @file_name, entry_name.to_s, comment: comment,
-                      extra: extra, compression_method: compression_method,
-                      compression_level: level
-                    )
-                  end
+      new_entry =
+        if entry_name.kind_of?(Entry) || entry_name.kind_of?(StreamableStream)
+          entry_name
+        else
+          Entry.new(
+            @file_name, entry_name.to_s, comment: comment, extra: extra,
+            compression_method: compression_method, compression_level: level
+          )
+        end
 
       init_next_entry(new_entry)
       @current_entry = new_entry

--- a/test/entry_test.rb
+++ b/test/entry_test.rb
@@ -26,7 +26,10 @@ class ZipEntryTest < MiniTest::Test
     assert_equal(TEST_COMPRESSIONMETHOD, entry.compression_method)
     assert_equal(TEST_NAME, entry.name)
     assert_equal(TEST_SIZE, entry.size)
-    assert_equal(TEST_TIME, entry.time)
+
+    # Reverse times when testing because we need to use DOSTime#== for the
+    # comparison, not Time#==.
+    assert_equal(entry.time, TEST_TIME)
   end
 
   def test_is_directory_and_is_file


### PR DESCRIPTION
When passing an `Entry` type to `File#get_output_stream` the entry is
used to create a `StreamableStream`, which preserves all the info in the
entry, such as timestamp, etc. But then in `put_next_entry` all that is
lost due to the test for `kind_of?(Entry)` which a `StreamableStream` is
not. See #503 for details.

This change tests for `StreamableStream`s in `put_next_entry` and uses
them directly. Some set-up within `Entry` needed to be made more robust
to cope with this, but otherwise it's a low impact change, which does
fix the problem.

The reason this case was being missed before is that the tests weren't
testing `get_output_stream` with an `Entry` object, so I have also added
that test too.

Fixes #503.