### PR TITLE
Fix reading unknown extra fields.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -61,6 +61,7 @@ Style/ClassAndModuleChildren:
     - 'lib/zip/extra_field/old_unix.rb'
     - 'lib/zip/extra_field/universal_time.rb'
     - 'lib/zip/extra_field/unix.rb'
+    - 'lib/zip/extra_field/unknown.rb'
     - 'lib/zip/extra_field/zip64.rb'
     - 'lib/zip/extra_field/zip64_placeholder.rb'
 

--- a/lib/zip/central_directory.rb
+++ b/lib/zip/central_directory.rb
@@ -174,7 +174,7 @@ module Zip
         unless offset.nil?
           io_save = io.tell
           io.seek(offset, IO::SEEK_SET)
-          entry.read_extra_field(read_local_extra_field(io))
+          entry.read_extra_field(read_local_extra_field(io), local: true)
           io.seek(io_save, IO::SEEK_SET)
         end
 

--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -313,7 +313,7 @@ module Zip
         raise ::Zip::Error, 'Truncated local zip entry header'
       end
 
-      read_extra_field(extra)
+      read_extra_field(extra, local: true)
       parse_zip64_extra(true)
       @local_header_size = calculate_local_header_size
     end
@@ -417,11 +417,11 @@ module Zip
       raise ::Zip::Error, 'Truncated cdir zip entry header'
     end
 
-    def read_extra_field(buf)
+    def read_extra_field(buf, local: false)
       if @extra.kind_of?(::Zip::ExtraField)
-        @extra.merge(buf) if buf
+        @extra.merge(buf, local: local) if buf
       else
-        @extra = ::Zip::ExtraField.new(buf)
+        @extra = ::Zip::ExtraField.new(buf, local: local)
       end
     end
 

--- a/lib/zip/extra_field/unknown.rb
+++ b/lib/zip/extra_field/unknown.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Zip
+  # A class to hold unknown extra fields so that they are preserved.
+  class ExtraField::Unknown
+    def initialize
+      @local_bin = +''
+      @cdir_bin = +''
+    end
+
+    def merge(binstr, local: false)
+      return if binstr.empty?
+
+      if local
+        @local_bin << binstr
+      else
+        @cdir_bin << binstr
+      end
+    end
+
+    def to_local_bin
+      @local_bin
+    end
+
+    def to_c_dir_bin
+      @cdir_bin
+    end
+
+    def ==(other)
+      @local_bin == other.to_local_bin && @cdir_bin == other.to_c_dir_bin
+    end
+  end
+end

--- a/test/extra_field_unknown_test.rb
+++ b/test/extra_field_unknown_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ZipExtraFieldUnknownTest < MiniTest::Test
+  def test_new
+    extra = ::Zip::ExtraField::Unknown.new
+    assert_empty(extra.to_c_dir_bin)
+    assert_empty(extra.to_local_bin)
+  end
+
+  def test_merge_cdir_then_local
+    extra = ::Zip::ExtraField::Unknown.new
+    field = "ux\v\x00\x01\x04\xF6\x01\x00\x00\x04\x14\x00\x00\x00"
+
+    extra.merge(field)
+    assert_empty(extra.to_local_bin)
+    assert_equal(field, extra.to_c_dir_bin)
+
+    extra.merge(field, local: true)
+    assert_equal(field, extra.to_local_bin)
+    assert_equal(field, extra.to_c_dir_bin)
+  end
+
+  def test_merge_local_only
+    extra = ::Zip::ExtraField::Unknown.new
+    field = "ux\v\x00\x01\x04\xF6\x01\x00\x00\x04\x14\x00\x00\x00"
+
+    extra.merge(field, local: true)
+    assert_equal(field, extra.to_local_bin)
+    assert_empty(extra.to_c_dir_bin)
+  end
+
+  def test_equality
+    extra1 = ::Zip::ExtraField::Unknown.new
+    extra2 = ::Zip::ExtraField::Unknown.new
+    assert_equal(extra1, extra2)
+
+    extra1.merge("ux\v\x00\x01\x04\xF6\x01\x00\x00\x04\x14\x00\x00\x00")
+    refute_equal(extra1, extra2)
+
+    extra2.merge("ux\v\x00\x01\x04\xF6\x01\x00\x00\x04\x14\x00\x00\x00")
+    assert_equal(extra1, extra2)
+
+    extra1.merge('foo', local: true)
+    refute_equal(extra1, extra2)
+
+    extra2.merge('foo', local: true)
+    assert_equal(extra1, extra2)
+  end
+end

--- a/test/local_entry_test.rb
+++ b/test/local_entry_test.rb
@@ -83,6 +83,7 @@ class ZipLocalEntryTest < MiniTest::Test
       'file.zip', 'entry_name', comment: 'my little comment', size: 400,
       extra: 'thisIsSomeExtraInformation', compressed_size: 100, crc: 987_654
     )
+    entry.extra.merge('thisIsSomeExtraInformation', local: true)
 
     write_to_file(LEH_FILE, CEH_FILE, entry)
     local_entry, central_entry = read_from_file(LEH_FILE, CEH_FILE)
@@ -153,18 +154,23 @@ class ZipLocalEntryTest < MiniTest::Test
 
   private
 
-  def compare_local_entry_headers(entry1, entry2)
+  def compare_common_entry_headers(entry1, entry2)
     assert_equal(entry1.compressed_size, entry2.compressed_size)
     assert_equal(entry1.crc, entry2.crc)
-    assert_equal(entry1.extra, entry2.extra)
     assert_equal(entry1.compression_method, entry2.compression_method)
     assert_equal(entry1.name, entry2.name)
     assert_equal(entry1.size, entry2.size)
     assert_equal(entry1.local_header_offset, entry2.local_header_offset)
   end
 
+  def compare_local_entry_headers(entry1, entry2)
+    compare_common_entry_headers(entry1, entry2)
+    assert_equal(entry1.extra.to_local_bin, entry2.extra.to_local_bin)
+  end
+
   def compare_c_dir_entry_headers(entry1, entry2)
-    compare_local_entry_headers(entry1, entry2)
+    compare_common_entry_headers(entry1, entry2)
+    assert_equal(entry1.extra.to_c_dir_bin, entry2.extra.to_c_dir_bin)
     assert_equal(entry1.comment, entry2.comment)
   end
 


### PR DESCRIPTION
When loading extra fields from both the central directory and local headers,
unknown fields were not merged correctly. They were being appended, which
means that we end up with the two versions stuck together - in some
cases duplicating the field completely.

This broke all kinds of things (like calculating the size of a local
header) in subtle ways.

This commit fixes this by implementing a new `Unknown` extra field type,
and making sure that when reading local and central extra fields they
are stored and preserved correctly. We cannot assume the unknown fields
use the same data in the local and central headers.

Fixes #505.