### PR TITLE
add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', head, jruby, jruby-head, truffleruby, truffleruby-head]
+        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', '3.1', head, jruby, jruby-head, truffleruby, truffleruby-head]
         include:
           - os: macos
             ruby: 2.4


### PR DESCRIPTION
This PR is to add Ruby 3.1 to CI.