### PR TITLE
Enable Zip64 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,10 +328,10 @@ end
 
 ### Zip64 Support
 
-By default, Zip64 support is disabled for writing. To enable it do this:
+By default, Zip64 support is enabled for writing. To disable it do this:
 
 ```ruby
-Zip.write_zip64_support = true
+Zip.write_zip64_support = false
 ```
 
 _NOTE_: If you will enable Zip64 writing then you will need zip extractor with Zip64 support to extract archive.

--- a/lib/zip.rb
+++ b/lib/zip.rb
@@ -61,7 +61,7 @@ module Zip
     @continue_on_exists_proc = false
     @sort_entries = false
     @default_compression = ::Zlib::DEFAULT_COMPRESSION
-    @write_zip64_support = false
+    @write_zip64_support = true
     @warn_invalid_date = true
     @case_insensitive_match = false
     @force_entry_names_encoding = nil

--- a/test/local_entry_test.rb
+++ b/test/local_entry_test.rb
@@ -62,6 +62,7 @@ class ZipLocalEntryTest < MiniTest::Test
   end
 
   def test_write_entry
+    ::Zip.write_zip64_support = false
     entry = ::Zip::Entry.new(
       'file.zip', 'entry_name', comment: 'my little comment', size: 400,
       extra: 'thisIsSomeExtraInformation', compressed_size: 100, crc: 987_654


### PR DESCRIPTION
Previously if RubyZip attempted to create an archive with more than
64K entries, the central directory would truncate the count. `unzip`
and `zipinfo` would fail with an error message such as:

```
error:  expected central file header signature not found (file #93272).
  (please check that you have transferred or created the zipfile in the
  appropriate BINARY mode and that you have compiled UnZip properly)
```

This generated a lot of confusion and a production issue since many
tools fail to decode a RubyZip-created archive if Zip64 is not enabled
for a large number of files. Since Zip64 support is now the norm,
enable this by default.