### PR TITLE
Fix unraised error on encrypted archives

### DIFF
--- a/lib/zip/input_stream.rb
+++ b/lib/zip/input_stream.rb
@@ -144,7 +144,7 @@ module Zip
       @current_entry = ::Zip::Entry.read_local_entry(@archive_io)
       return if @current_entry.nil?
 
-      if @current_entry.encrypted? && @decrypter.kind_of?(NullEncrypter)
+      if @current_entry.encrypted? && @decrypter.kind_of?(NullDecrypter)
         raise Error,
               'A password is required to decode this zip file'
       end

--- a/test/input_stream_test.rb
+++ b/test/input_stream_test.rb
@@ -91,6 +91,14 @@ class ZipInputStreamTest < MiniTest::Test
     end
   end
 
+  def test_open_encrypted_archive_raises_error
+    ::Zip::InputStream.open('test/data/zipWithEncryption.zip') do |zis|
+      assert_raises(::Zip::Error) do
+        zis.get_next_entry
+      end
+    end
+  end
+
   def test_size_no_entry
     zis = ::Zip::InputStream.open(TestZipFile::TEST_ZIP2.zip_name)
     assert_nil(zis.size)


### PR DESCRIPTION
Currently, we raise an error for encrypted zip entries if `@decrypter` is a `NullEncryper`. However, the default value for `@decrypter` is actually `NullDecrypter`. 