### PR TITLE
Zip::InputStream#read(0) should return an empty string

### DIFF
--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -36,7 +36,7 @@ module Zip
                end
 
         if tbuf.nil? || tbuf.empty?
-          return nil if number_of_bytes
+          return nil if number_of_bytes&.positive?
 
           return ''
         end

--- a/test/input_stream_test.rb
+++ b/test/input_stream_test.rb
@@ -191,7 +191,7 @@ class ZipInputStreamTest < MiniTest::Test
 
   def test_read_with_zero_returns_empty_string
     ::Zip::InputStream.open(TestZipFile::TEST_ZIP2.zip_name) do |zis|
-      assert_equal("", zis.read(0))
+      assert_equal('', zis.read(0))
     end
   end
 

--- a/test/input_stream_test.rb
+++ b/test/input_stream_test.rb
@@ -189,6 +189,12 @@ class ZipInputStreamTest < MiniTest::Test
     end
   end
 
+  def test_read_with_zero_returns_empty_string
+    ::Zip::InputStream.open(TestZipFile::TEST_ZIP2.zip_name) do |zis|
+      assert_equal("", zis.read(0))
+    end
+  end
+
   def test_rewind
     ::Zip::InputStream.open(TestZipFile::TEST_ZIP2.zip_name) do |zis|
       e = zis.get_next_entry


### PR DESCRIPTION
`Zip::InputStream#read` returns `nil` when `number_of_bytes` is `0`.

It is not compatible with [`IO#read(0)`](https://ruby-doc.org/3.2.0/IO.html#method-i-read:~:text=If%20maxlen%20is%20zero%2C%20returns%20an%20empty%20string.) which returns an empty string.

```rb
open("/etc/passwd") {|io| io.read(0) }
#=> ""
```
