### PR TITLE
add non-deterministic breaking test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,27 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
 
+    - name: Chromedriver non-deterministic test
+      run: |
+        curl "https://chromedriver.storage.googleapis.com/110.0.5481.77/chromedriver_linux64.zip" > chromedriver_linux64.zip
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+
     - name: Run the tests
       env:
         RUBYOPT: --enable-yjit -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,15 @@ jobs:
         rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
         rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
         rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver && RUBY_YJIT_ENABLE=true bundle exec ruby test/yjit_test.rb && chmod +x ./chromedriver && ./chromedriver --version
+        rm -f chromedriver
 
     - name: Run the tests
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu]
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', head, jruby, jruby-head, truffleruby, truffleruby-head]
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', head, jruby, jruby-head, truffleruby, truffleruby-head]
         include:
           - os: macos
             ruby: '2.5'
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby: ['3.1', head]
+        ruby: ['3.1', '3.2', head]
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: true
     steps:

--- a/test/yjit_test.rb
+++ b/test/yjit_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'zip'
 
 driver_name = 'chromedriver'

--- a/test/yjit_test.rb
+++ b/test/yjit_test.rb
@@ -1,0 +1,9 @@
+require 'zip'
+
+driver_name = 'chromedriver'
+Zip::File.open('.chromedriver_linux64.zip') do |zip_file|
+  driver = zip_file.get_entry(driver_name)
+  f_path = File.join(Dir.pwd, driver.name)
+  FileUtils.mkdir_p(File.dirname(f_path)) unless File.exist?(File.dirname(f_path))
+  zip_file.extract(driver, f_path)
+end

--- a/test/yjit_test.rb
+++ b/test/yjit_test.rb
@@ -2,6 +2,8 @@
 
 require 'zip'
 
+puts "Ruby YJIT Enabled: #{RubyVM::YJIT.enabled?}"
+
 driver_name = 'chromedriver'
 Zip::File.open('./chromedriver_linux64.zip') do |zip_file|
   driver = zip_file.get_entry(driver_name)

--- a/test/yjit_test.rb
+++ b/test/yjit_test.rb
@@ -3,7 +3,7 @@
 require 'zip'
 
 driver_name = 'chromedriver'
-Zip::File.open('.chromedriver_linux64.zip') do |zip_file|
+Zip::File.open('./chromedriver_linux64.zip') do |zip_file|
   driver = zip_file.get_entry(driver_name)
   f_path = File.join(Dir.pwd, driver.name)
   FileUtils.mkdir_p(File.dirname(f_path)) unless File.exist?(File.dirname(f_path))


### PR DESCRIPTION
See https://github.com/titusfortner/webdrivers/issues/245

I believe I've found a non-deterministic bug related to YJIT + rubyzip. This PR has a clumsy breaking test that should trigger the issue I'm seeing in my own projects. I know this isn't "clean" yet but please approve the Github Action workflow to at least verify the issue.

The breaking test does the following:

1. Downloads `chromedriver` zip
2. Repeatedly attempts to run a ruby script that unzips the file using Rubyzip, with YJIT enabled
3. Expected behavior: it will segfault.

I'm finding that the reason it segfaults is that the binary file produced by the decompression is not reliably the same size (it's off by a few bytes).