### PR TITLE
Ensure that entries can be extracted safely without path traversal.

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -245,11 +245,16 @@ module Zip
       add(entry, src_path)
     end
 
-    # Extracts entry to file dest_path.
-    def extract(entry, dest_path, &block)
+    # Extracts `entry` to a file at `entry_path`, with `destination_directory`
+    # as the base location in the filesystem.
+    #
+    # NB: The caller is responsible for making sure `destination_directory` is
+    # safe, if it is passed.
+    def extract(entry, entry_path = nil, destination_directory: '.', &block)
       block ||= proc { ::Zip.on_exists_proc }
       found_entry = get_entry(entry)
-      found_entry.extract(dest_path, &block)
+      entry_path ||= found_entry.name
+      found_entry.extract(entry_path, destination_directory: destination_directory, &block)
     end
 
     # Commits changes that has been made since the previous commit to

--- a/test/file_extract_directory_test.rb
+++ b/test/file_extract_directory_test.rb
@@ -48,7 +48,7 @@ class ZipFileExtractDirectoryTest < MiniTest::Test
     called = false
     extract_test_dir do |entry, dest_path|
       called = true
-      assert_equal(TEST_OUT_NAME, dest_path)
+      assert_equal(File.absolute_path(TEST_OUT_NAME), dest_path)
       assert(entry.directory?)
       true
     end

--- a/test/file_extract_test.rb
+++ b/test/file_extract_test.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 class ZipFileExtractTest < MiniTest::Test
   include CommonZipFileFixture
   EXTRACTED_FILENAME = 'test/data/generated/extEntry'
+  EXTRACTED_FILENAME_ABS = ::File.absolute_path(EXTRACTED_FILENAME)
   ENTRY_TO_EXTRACT, *REMAINING_ENTRIES = TEST_ZIP.entry_names.reverse
 
   def setup
@@ -58,7 +59,7 @@ class ZipFileExtractTest < MiniTest::Test
     ::Zip::File.open(TEST_ZIP.zip_name) do |zf|
       zf.extract(zf.entries.first, EXTRACTED_FILENAME) do |entry, extract_loc|
         called_correctly = zf.entries.first == entry &&
-                           extract_loc == EXTRACTED_FILENAME
+                           extract_loc == EXTRACTED_FILENAME_ABS
         true
       end
     end

--- a/test/file_options_test.rb
+++ b/test/file_options_test.rb
@@ -7,12 +7,15 @@ class FileOptionsTest < MiniTest::Test
   TXTPATH = ::File.expand_path(::File.join('data', 'file1.txt'), __dir__).freeze
   TXTPATH_600 = ::File.join(Dir.tmpdir, 'file1.600.txt').freeze
   TXTPATH_755 = ::File.join(Dir.tmpdir, 'file1.755.txt').freeze
-  EXTPATH_1 = ::File.join(Dir.tmpdir, 'extracted_1.txt').freeze
-  EXTPATH_2 = ::File.join(Dir.tmpdir, 'extracted_2.txt').freeze
-  EXTPATH_3 = ::File.join(Dir.tmpdir, 'extracted_3.txt').freeze
   ENTRY_1 = 'entry_1.txt'
   ENTRY_2 = 'entry_2.txt'
   ENTRY_3 = 'entry_3.txt'
+  EXTRACT_1 = 'extracted_1.txt'
+  EXTRACT_2 = 'extracted_2.txt'
+  EXTRACT_3 = 'extracted_3.txt'
+  EXTPATH_1 = ::File.join(Dir.tmpdir, EXTRACT_1).freeze
+  EXTPATH_2 = ::File.join(Dir.tmpdir, EXTRACT_2).freeze
+  EXTPATH_3 = ::File.join(Dir.tmpdir, EXTRACT_3).freeze
 
   def teardown
     ::File.unlink(ZIPPATH) if ::File.exist?(ZIPPATH)
@@ -37,9 +40,9 @@ class FileOptionsTest < MiniTest::Test
     end
 
     ::Zip::File.open(ZIPPATH, restore_permissions: true) do |zip|
-      zip.extract(ENTRY_1, EXTPATH_1)
-      zip.extract(ENTRY_2, EXTPATH_2)
-      zip.extract(ENTRY_3, EXTPATH_3)
+      zip.extract(ENTRY_1, EXTRACT_1, destination_directory: Dir.tmpdir)
+      zip.extract(ENTRY_2, EXTRACT_2, destination_directory: Dir.tmpdir)
+      zip.extract(ENTRY_3, EXTRACT_3, destination_directory: Dir.tmpdir)
     end
 
     assert_equal(::File.stat(TXTPATH).mode, ::File.stat(EXTPATH_1).mode)
@@ -61,9 +64,9 @@ class FileOptionsTest < MiniTest::Test
     end
 
     ::Zip::File.open(ZIPPATH, restore_permissions: false) do |zip|
-      zip.extract(ENTRY_1, EXTPATH_1)
-      zip.extract(ENTRY_2, EXTPATH_2)
-      zip.extract(ENTRY_3, EXTPATH_3)
+      zip.extract(ENTRY_1, EXTRACT_1, destination_directory: Dir.tmpdir)
+      zip.extract(ENTRY_2, EXTRACT_2, destination_directory: Dir.tmpdir)
+      zip.extract(ENTRY_3, EXTRACT_3, destination_directory: Dir.tmpdir)
     end
 
     default_perms = (Zip::RUNNING_ON_WINDOWS ? 0o100_644 : 0o100_666) - ::File.umask
@@ -86,9 +89,9 @@ class FileOptionsTest < MiniTest::Test
     end
 
     ::Zip::File.open(ZIPPATH) do |zip|
-      zip.extract(ENTRY_1, EXTPATH_1)
-      zip.extract(ENTRY_2, EXTPATH_2)
-      zip.extract(ENTRY_3, EXTPATH_3)
+      zip.extract(ENTRY_1, EXTRACT_1, destination_directory: Dir.tmpdir)
+      zip.extract(ENTRY_2, EXTRACT_2, destination_directory: Dir.tmpdir)
+      zip.extract(ENTRY_3, EXTRACT_3, destination_directory: Dir.tmpdir)
     end
 
     assert_equal(::File.stat(TXTPATH).mode, ::File.stat(EXTPATH_1).mode)
@@ -103,8 +106,8 @@ class FileOptionsTest < MiniTest::Test
     end
 
     ::Zip::File.open(ZIPPATH, restore_times: true) do |zip|
-      zip.extract(ENTRY_1, EXTPATH_1)
-      zip.extract(ENTRY_2, EXTPATH_2)
+      zip.extract(ENTRY_1, EXTRACT_1, destination_directory: Dir.tmpdir)
+      zip.extract(ENTRY_2, EXTRACT_2, destination_directory: Dir.tmpdir)
     end
 
     assert_time_equal(::File.mtime(TXTPATH), ::File.mtime(EXTPATH_1))
@@ -118,8 +121,8 @@ class FileOptionsTest < MiniTest::Test
     end
 
     ::Zip::File.open(ZIPPATH, restore_times: false) do |zip|
-      zip.extract(ENTRY_1, EXTPATH_1)
-      zip.extract(ENTRY_2, EXTPATH_2)
+      zip.extract(ENTRY_1, EXTRACT_1, destination_directory: Dir.tmpdir)
+      zip.extract(ENTRY_2, EXTRACT_2, destination_directory: Dir.tmpdir)
     end
 
     assert_time_equal(::Time.now, ::File.mtime(EXTPATH_1))
@@ -133,8 +136,8 @@ class FileOptionsTest < MiniTest::Test
     end
 
     ::Zip::File.open(ZIPPATH) do |zip|
-      zip.extract(ENTRY_1, EXTPATH_1)
-      zip.extract(ENTRY_2, EXTPATH_2)
+      zip.extract(ENTRY_1, EXTRACT_1, destination_directory: Dir.tmpdir)
+      zip.extract(ENTRY_2, EXTRACT_2, destination_directory: Dir.tmpdir)
     end
 
     assert_time_equal(::File.mtime(TXTPATH), ::File.mtime(EXTPATH_1))
@@ -143,20 +146,19 @@ class FileOptionsTest < MiniTest::Test
 
   def test_get_find_consistency
     testzip = ::File.expand_path(::File.join('data', 'globTest.zip'), __dir__)
-    file_f = ::File.expand_path('f_test.txt', Dir.tmpdir)
-    file_g = ::File.expand_path('g_test.txt', Dir.tmpdir)
+    Dir.mktmpdir do |tmp|
+      file_f = ::File.expand_path('f_test.txt', tmp)
+      file_g = ::File.expand_path('g_test.txt', tmp)
 
-    ::Zip::File.open(testzip) do |zip|
-      e1 = zip.find_entry('globTest/food.txt')
-      e1.extract(file_f)
-      e2 = zip.get_entry('globTest/food.txt')
-      e2.extract(file_g)
+      ::Zip::File.open(testzip) do |zip|
+        e1 = zip.find_entry('globTest/food.txt')
+        e1.extract('f_test.txt', destination_directory: tmp)
+        e2 = zip.get_entry('globTest/food.txt')
+        e2.extract('g_test.txt', destination_directory: tmp)
+      end
+
+      assert_time_equal(::File.mtime(file_f), ::File.mtime(file_g))
     end
-
-    assert_time_equal(::File.mtime(file_f), ::File.mtime(file_g))
-  ensure
-    ::File.unlink(file_f)
-    ::File.unlink(file_g)
   end
 
   private


### PR DESCRIPTION
This commit adds a parameter to the `File#extract` and `Entry#extract` methods so that a base destination directory can be specified for extracting archives in bulk to somewhere in the filesystem that isn't the current working directory. This directory is `.` by default. It is combined with the entry path - which shouldn't but could have relative directories (e.g. `..`) in it - and tested for safety before extracting.

Resolves #540.