### PR TITLE
Add two Windows head builds to CI, update README.md CI info

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,11 @@ jobs:
         os: [ubuntu]
         ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', head, jruby, jruby-head, truffleruby, truffleruby-head]
         include:
-          - os: macos
-            ruby: '2.5'
-          - os: windows
-            ruby: '2.5'
+          - { os: macos  , ruby: '2.5' }
+          - { os: windows, ruby: '2.5' }
+          # head builds
+          - { os: windows, ruby: ucrt  }
+          - { os: windows, ruby: mswin }
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.os == 'windows' }}
     steps:
@@ -26,10 +27,6 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         rubygems: '3.2.3'
         bundler-cache: true
-
-    - name: Install other dependencies
-      if: matrix.os == 'windows'
-      run: choco install zip
 
     - name: Run the tests
       env:

--- a/README.md
+++ b/README.md
@@ -373,10 +373,10 @@ Please see the table below for what we think the current situation is. Note: an 
 
 | OS/Ruby | 2.5 | 2.6 | 2.7 | 3.0 | 3.1 | 3.1 +YJIT | Head | Head +YJIT | JRuby 9.3.2.0 | JRuby Head | Truffleruby 21.3.0 | Truffleruby Head |
 |---------|-----|-----|-----|-----|-----|----------|------|-----------|----------------|------------|--------------------|------------------|
-|Ubuntu 20.04.3| CI | CI | CI | CI | CI | ci | ci | ci | CI | ci | CI | ci |
-|Mac OS 11.6.2| CI | x | x | x | x | ci |  | ci | x |  | x |  |
+|Ubuntu 22.04| CI | CI | CI | CI | CI | ci | ci | ci | CI | ci | CI | ci |
+|Mac OS 12.6.7| CI | x | x | x | x | ci |  | ci | x |  | x |  |
 |Windows 10|  |  | x |  |  |  |  |  |  |  |  |  |
-|Windows Server 2019| CI |  |  |  |  |  |  |  |  |  |  |  |
+|Windows Server 2022| CI |  |  |  |  |  | CI&nbsp;mswin</br>CI&nbsp;ucrt |  |  |  |  |  |
 
 Key: `CI` - tested in CI, should work; `ci` - tested in CI, might fail; `x` - known working; `o` - known failing.
 


### PR DESCRIPTION
The setup-ruby action installs an MSYS2 version of zip, so the step running `choco install zip` isn't needed.