### PR TITLE
Fix `File#write_buffer` to always return the given `io`

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -412,7 +412,7 @@ module Zip
 
     # Write buffer write changes to buffer and return
     def write_buffer(io = ::StringIO.new)
-      return unless commit_required?
+      return io unless commit_required?
 
       ::Zip::OutputStream.write_buffer(io) do |zos|
         @entry_set.each { |e| e.write_to_zip_output_stream(zos) }

--- a/test/file_test.rb
+++ b/test/file_test.rb
@@ -141,7 +141,7 @@ class ZipFileTest < MiniTest::Test
     assert zf.entries.map(&:name).include?('zippedruby1.rb')
 
     # Ensure the buffer isn't changed.
-    zf.write_buffer(string_io)
+    assert_same string_io, zf.write_buffer(string_io)
     assert_equal(data, string_io.string)
   end
 


### PR DESCRIPTION
Ref: https://github.com/rubyzip/rubyzip/commit/ef89a62b70d0b0c43a9579d414d5a917fef0cdc3

This fixes a regression in 2.4.rc1.

cc @hainesr 