### PR TITLE
Zip::File#write_buffer doesn't assume we're writing to the original IO

### DIFF
--- a/lib/zip/file.rb
+++ b/lib/zip/file.rb
@@ -412,8 +412,6 @@ module Zip
 
     # Write buffer write changes to buffer and return
     def write_buffer(io = ::StringIO.new)
-      return io unless commit_required?
-
       ::Zip::OutputStream.write_buffer(io) do |zos|
         @entry_set.each { |e| e.write_to_zip_output_stream(zos) }
         zos.comment = comment


### PR DESCRIPTION
`write_buffer` may be called with another IO than the one that was used to open/read the file. Hence even if there is no change, the caller may expect the archive to be written in the IO.

NB: a bunch of test fails, but I'm not sure I fully understand the API and that my assumptions are correct, hence why I'm opening early.

Perhaps we're using the API incorrectly and we ought to rewrite our code?