### PR TITLE
Suppress "literal string will be frozen in the future" warning

### DIFF
--- a/lib/zip/extra_field/ntfs.rb
+++ b/lib/zip/extra_field/ntfs.rb
@@ -51,7 +51,7 @@ module Zip
       # reserved 0 and tag 1
       s = [0, 1].pack('Vv')
 
-      tag1 = ''.force_encoding(Encoding::BINARY)
+      tag1 = ''.b
       if @mtime
         tag1 << [to_ntfs_time(@mtime)].pack('Q<')
         if @atime


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20205

This patch will suppress the "literal string will be frozen in the future" warning on the 2.4 branch.

Steps to reproduce
---

Run the following commands with ruby 3.4.0preview1:

```console
$ cd /tmp
$ git clone git@github.com:rubyzip/rubyzip.git
$ cd rubyzip
$ git switch 2.4
$ bundle install
$ ruby -I lib -W:deprecated -e '
require "zip"

Zip::File.open("test/data/ntfs.zip") do |zip_file|
  zip_file.each do |entry|
    puts entry.get_input_stream.read
  end
end
'
```

Expected result
---

```console
ntfs test
```

Actual result
---

```console
/private/tmp/rubyzip/lib/zip/extra_field/ntfs.rb:54: warning: literal string will be frozen in the future
ntfs test
```

Environment
---

```console
$ ruby -v
ruby 3.4.0preview1 (2024-05-16 master 9d69619623) [x86_64-darwin23]
```