### PR TITLE
Opt-in for MFA requirement explicitly on 2.4

### DIFF
--- a/rubyzip.gemspec
+++ b/rubyzip.gemspec
@@ -16,11 +16,12 @@ Gem::Specification.new do |s|
   s.require_paths         = ['lib']
   s.license               = 'BSD 2-Clause'
   s.metadata              = {
-    'bug_tracker_uri'   => 'https://github.com/rubyzip/rubyzip/issues',
-    'changelog_uri'     => "https://github.com/rubyzip/rubyzip/blob/v#{s.version}/Changelog.md",
-    'documentation_uri' => "https://www.rubydoc.info/gems/rubyzip/#{s.version}",
-    'source_code_uri'   => "https://github.com/rubyzip/rubyzip/tree/v#{s.version}",
-    'wiki_uri'          => 'https://github.com/rubyzip/rubyzip/wiki'
+    'bug_tracker_uri'       => 'https://github.com/rubyzip/rubyzip/issues',
+    'changelog_uri'         => "https://github.com/rubyzip/rubyzip/blob/v#{s.version}/Changelog.md",
+    'documentation_uri'     => "https://www.rubydoc.info/gems/rubyzip/#{s.version}",
+    'source_code_uri'       => "https://github.com/rubyzip/rubyzip/tree/v#{s.version}",
+    'wiki_uri'              => 'https://github.com/rubyzip/rubyzip/wiki',
+    'rubygems_mfa_required' => 'true'
   }
   s.required_ruby_version = '>= 2.4'
   s.add_development_dependency 'minitest', '~> 5.4'


### PR DESCRIPTION
As a pupular gem, `rubyzip` implicitly requires that all privileged operations by any of the owners require OTP.

By explicitly setting `rubygems_mfa_required` metadata, the gem will show "NEW VERSIONS REQUIRE MFA" and "VERSION PUBLISHED WITH MFA" in the sidebar at https://rubygems.org/gems/rubyzip

NOTE: The explicit opt-in was introduced in the `master` branch via 1c06454, but has not been backported to `2.4`

Ref:
- https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html
- https://guides.rubygems.org/mfa-requirement-opt-in/