### PR TITLE
Enhance changelog and readme

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -61,6 +61,29 @@ Tooling/internal:
 - Update rubocop again and run it in CI. [#444](https://github.com/rubyzip/rubyzip/pull/444)
 - Fix a test that was incorrect on big-endian architectures. [#445](https://github.com/rubyzip/rubyzip/pull/445)
 
+# 2.4.1 (2025-01-05)
+
+*This is a re-release of version 2.4 with a full version number string. We need to move to version 2.4.1 due to the canonical version number 2.4 now being taken in Rubygems.*
+
+Tooling:
+
+- Opt-in for MFA requirement explicitly on 2.4 branch.
+
+# 2.4 (2025-01-04) - Yanked
+
+*Yanked due to incorrect version number format (2.4 vs 2.4.0).*
+
+- Ensure compatibility with `--enable-frozen-string-literal`.
+- Ensure `File.open_buffer` doesn't rewrite unchanged data. This is a backport of the fix on the 3.x branch.
+- Enable use of the version 3 calling style (mainly named parameters) wherever possible, while retaining version 2.x compatibility.
+- Add (switchable) warning messages to methods that are changed or removed in version 3.x.
+
+Tooling:
+
+- Switch to using GitHub Actions (from Travis).
+- Update Rubocop versions and configuration.
+- Update actions with latest rubies.
+
 # 2.3.2 (2021-07-05)
 
 - A "dummy" release to warn about breaking changes coming in version 3.0. This updated version uses the Gem `post_install_message` instead of printing to `STDERR`.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The public API of some classes has been modernized to use named parameters for o
 
 Version 3.x requires at least Ruby 3.0.
 
-Version 2.x requires at least Ruby 2.4, and is known to work on Ruby 3.1.
+Version 2.x requires at least Ruby 2.4, and is known to work on Ruby 3.x.
 
 It is not recommended to use any versions of Rubyzip earlier than 2.3 due to security issues.
 


### PR DESCRIPTION
- Keep the `master` changelog up to date until with 2.4 releases. This should help with dependabot's sourced changelog. Example: https://github.com/alphagov/locations-api/pull/551
- Fix the Ruby versions known working with 2.x series