### PR TITLE
Fix JRuby CI tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@
 source 'https://rubygems.org'
 
 gemspec
+
+# TODO: remove when JRuby 9.4.10.0 will be released and available on CI
+# Ref: https://github.com/jruby/jruby/issues/7262
+gem 'jar-dependencies', '0.4.1' if RUBY_PLATFORM.include?('java')


### PR DESCRIPTION
Pin `jar-dependencies` to `0.4.1`.

Ref: jruby/jruby#7262

Close #626