### PR TITLE
Update README with Ruby version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The public API of some classes has been modernized to use named parameters for o
 
 Version 3.x requires at least Ruby 3.0.
 
-Version 2.x requires at least Ruby 2.4, and is known to work on Ruby 3.1.
+Version 2.x requires at least Ruby 2.4, and is known to work on Ruby 3.x.
 
 It is not recommended to use any versions of Rubyzip earlier than 2.3 due to security issues.
 


### PR DESCRIPTION
This commit updates the README to reflect the Ruby versions that are known to work with version 2.x of the library. Specifically, it documents that version 2.x works on Ruby 3.x.

Ref: 0001864cfe0a1e76879179dfa1ba7b9e60d5a991