### PR TITLE
Fix CI against JRuby, JRuby-head, and Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        rubygems: '3.5.23'
+        rubygems: latest
         bundler-cache: true
 
     - name: Run the tests

--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,7 @@ gemspec
 
 # TODO: remove when JRuby 9.4.10.0 will be released and available on CI
 # Ref: https://github.com/jruby/jruby/issues/7262
-gem 'jar-dependencies', '0.4.1' if RUBY_PLATFORM.include?('java')
+if RUBY_PLATFORM.include?('java')
+  gem 'jar-dependencies', '0.4.1'
+  gem 'ruby-maven', '3.3.13'
+end

--- a/rubyzip.gemspec
+++ b/rubyzip.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
 
   s.add_development_dependency 'minitest', '~> 5.22.0'
-  s.add_development_dependency 'rake', '~> 13.1.0'
+  s.add_development_dependency 'rake', '~> 13.2.0'
   s.add_development_dependency 'rdoc', '~> 6.6.2'
   s.add_development_dependency 'rubocop', '~> 1.61.0'
   s.add_development_dependency 'rubocop-performance', '~> 1.20.0'


### PR DESCRIPTION
Additionally:
- Use `latest` rubygems, instead of specifying a version and keeping
  it up to date
- Bump `rake` dependency to `~> 13.2.0` to allow tests to pass against
  Windows