### PR TITLE
entry: fix direct `require` by requiring `constants`

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -2,6 +2,7 @@
 
 require 'pathname'
 
+require_relative 'constants'
 require_relative 'dirtyable'
 
 module Zip


### PR DESCRIPTION
Without this, we see the following failure:

```
$ ruby -e'require "zip/entry"'
/usr/lib/ruby/gems/3.2.0/gems/rubyzip-3.0.0/lib/zip/entry.rb:13:in `<class:Entry>': uninitialized constant Zip::COMPRESSION_METHOD_STORE (NameError)

    STORED   = ::Zip::COMPRESSION_METHOD_STORE
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
	from /usr/lib/ruby/gems/3.2.0/gems/rubyzip-3.0.0/lib/zip/entry.rb:9:in `<module:Zip>'
	from /usr/lib/ruby/gems/3.2.0/gems/rubyzip-3.0.0/lib/zip/entry.rb:7:in `<top (required)>'
	from <internal:/usr/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:160:in `require'
	from <internal:/usr/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:160:in `rescue in require'
	from <internal:/usr/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:40:in `require'
	from -e:1:in `<main>'
<internal:/usr/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require': cannot load such file -- zip/entry (LoadError)
	from <internal:/usr/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:86:in `require'
	from -e:1:in `<main>'
```