### PR TITLE
entry: escape filename pattern when matching in `#name_safe?`

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -230,7 +230,7 @@ module Zip
       return false unless cleanpath.relative?
 
       root = ::File::SEPARATOR
-      naive = ::File.join(root, cleanpath.to_s)
+      naive = Regexp.escape(::File.join(root, cleanpath.to_s))
       # Allow for Windows drive mappings at the root.
       ::File.absolute_path(cleanpath.to_s, root).match?(/([A-Z]:)?#{naive}/i)
     end


### PR DESCRIPTION
After upgrading to 3.0.0, I found filename with parentheses treated as "not safe".

```
[1] pry(main)> require 'zip/version'
=> true
[2] pry(main)> Zip::VERSION
=> "2.4.1"
[3] pry(main)> Zip::File.open("/Users/syi/projects/sample.zip").entries.first.name
=> "filename with (parentheses)"
[4] pry(main)> Zip::File.open("/Users/syi/projects/sample.zip").entries.first.name_safe?
=> true
```

```
[1] pry(main)> require 'zip/version'
=> true
[2] pry(main)> Zip::VERSION
=> "3.0.0"
[3] pry(main)> Zip::File.open("/Users/syi/projects/sample.zip").entries.first.name
=> "filename with (parentheses)"
[4] pry(main)> Zip::File.open("/Users/syi/projects/sample.zip").entries.first.name_safe?
=> false
```

It looks like regular expressions matching for Windows drive mapping doesn't have any escapes, so I added it.