### PR TITLE
fixed sysread having a frozen string literal as default

### DIFF
--- a/lib/zip/input_stream.rb
+++ b/lib/zip/input_stream.rb
@@ -90,7 +90,7 @@ module Zip
     end
 
     # Modeled after IO.sysread
-    def sysread(length = nil, outbuf = '')
+    def sysread(length = nil, outbuf = String.new)
       @decompressor.read(length, outbuf)
     end
 


### PR DESCRIPTION
Without this '' will be frozen and cause issues when frozen string literals are enabled # frozen_string_literal: true
And third party gems sometimes do a .sysread without parameters