### PR TITLE
Improve the IO pipeline when decompressing.

### DIFF
--- a/lib/zip/crypto/aes_encryption.rb
+++ b/lib/zip/crypto/aes_encryption.rb
@@ -112,7 +112,8 @@ module Zip
       @hmac = OpenSSL::HMAC.new(enc_hmac_key, OpenSSL::Digest.new('SHA1'))
     end
 
-    def check_integrity(auth_code)
+    def check_integrity!(io)
+      auth_code = io.read(AUTHENTICATION_CODE_LENGTH)
       raise Error, 'Integrity fault' if @hmac.digest[0...AUTHENTICATION_CODE_LENGTH] != auth_code
     end
   end

--- a/lib/zip/crypto/decrypted_io.rb
+++ b/lib/zip/crypto/decrypted_io.rb
@@ -20,9 +20,7 @@ module Zip
         buffer << produce_input
       end
 
-      if @decrypter.kind_of?(::Zip::AESDecrypter) && input_finished?
-        @decrypter.check_integrity(@io.read(::Zip::AESEncryption::AUTHENTICATION_CODE_LENGTH))
-      end
+      @decrypter.check_integrity!(@io) if input_finished?
 
       outbuf.replace(buffer.slice!(0...(length || buffer.bytesize)))
     end

--- a/lib/zip/crypto/decrypted_io.rb
+++ b/lib/zip/crypto/decrypted_io.rb
@@ -8,30 +8,27 @@ module Zip
       @io = io
       @decrypter = decrypter
       @bytes_remaining = compressed_size
+      @buffer = +''
     end
 
     def read(length = nil, outbuf = +'')
       return (length.nil? || length.zero? ? '' : nil) if eof?
 
-      while length.nil? || (buffer.bytesize < length)
+      while length.nil? || (@buffer.bytesize < length)
         break if input_finished?
 
-        buffer << produce_input
+        @buffer << produce_input
       end
 
       @decrypter.check_integrity!(@io) if input_finished?
 
-      outbuf.replace(buffer.slice!(0...(length || buffer.bytesize)))
+      outbuf.replace(@buffer.slice!(0...(length || @buffer.bytesize)))
     end
 
     private
 
     def eof?
-      buffer.empty? && input_finished?
-    end
-
-    def buffer
-      @buffer ||= +''
+      @buffer.empty? && input_finished?
     end
 
     def input_finished?

--- a/lib/zip/crypto/null_encryption.rb
+++ b/lib/zip/crypto/null_encryption.rb
@@ -28,16 +28,6 @@ module Zip
 
     def reset!; end
   end
-
-  class NullDecrypter < Decrypter # :nodoc:
-    include NullEncryption
-
-    def decrypt(data)
-      data
-    end
-
-    def reset!(_header); end
-  end
 end
 
 # Copyright (C) 2002, 2003 Thomas Sondergaard

--- a/lib/zip/crypto/traditional_encryption.rb
+++ b/lib/zip/crypto/traditional_encryption.rb
@@ -86,6 +86,8 @@ module Zip
       end
     end
 
+    def check_integrity!(_io); end
+
     private
 
     def decode(num)

--- a/lib/zip/input_stream.rb
+++ b/lib/zip/input_stream.rb
@@ -55,7 +55,7 @@ module Zip
       super()
       @archive_io = get_io(context, offset)
       @decompressor = ::Zip::NullDecompressor
-      @decrypter = decrypter || ::Zip::NullDecrypter.new
+      @decrypter = decrypter
       @current_entry = nil
       @complete_entry = nil
     end
@@ -146,9 +146,7 @@ module Zip
 
     def assemble_io # :nodoc:
       io = if @current_entry.encrypted?
-             if @decrypter.kind_of?(NullDecrypter)
-               raise Error, 'A password is required to decode this zip file'
-             end
+             raise Error, 'A password is required to decode this zip file.' if @decrypter.nil?
 
              get_decrypted_io
            else

--- a/test/crypto/null_encryption_test.rb
+++ b/test/crypto/null_encryption_test.rb
@@ -31,29 +31,3 @@ class NullEncrypterTest < MiniTest::Test
     assert_respond_to @encrypter, :reset!
   end
 end
-
-class NullDecrypterTest < MiniTest::Test
-  def setup
-    @decrypter = ::Zip::NullDecrypter.new
-  end
-
-  def test_header_bytesize
-    assert_equal 0, @decrypter.header_bytesize
-  end
-
-  def test_gp_flags
-    assert_equal 0, @decrypter.gp_flags
-  end
-
-  def test_decrypt
-    assert_nil @decrypter.decrypt(nil)
-
-    ['', 'a' * 10, 0xffffffff].each do |data|
-      assert_equal data, @decrypter.decrypt(data)
-    end
-  end
-
-  def test_reset!
-    assert_respond_to @decrypter, :reset!
-  end
-end


### PR DESCRIPTION
The key change here is to only use the decryption classes, and `DecryptedIo` when we're actually needed to decrypt something.

Some other simplifications are also included.