### PR TITLE
Add lib/rubyzip.rb for explicit gem loading

### DIFF
--- a/lib/rubyzip.rb
+++ b/lib/rubyzip.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative 'zip'


### PR DESCRIPTION
## Summary

This PR adds a `lib/rubyzip.rb` file that requires `zip.rb`, allowing the gem to be loaded automatically by Bundler without explicit configuration.

## Motivation

Currently, users need to specify `require: 'zip'` in their Gemfile:

```ruby
gem 'rubyzip', require: 'zip'
```

This is because Bundler looks for `lib/rubyzip.rb` by default (matching the gem name), but the gem only provides `lib/zip.rb`.

## Benefits

1. **Better Bundler integration**: `Bundler.require` works without explicit `require: 'zip'` configuration
2. **Follows gem conventions**: Gem name matches the require path
3. **Backward compatible**: Existing code using `require 'zip'` continues to work unchanged
4. **No breaking changes**: Zero impact on existing functionality

## Implementation

- Added `lib/rubyzip.rb` that simply requires `zip.rb`
- All existing tests pass
- Rubocop checks pass

Related to #132 (though this doesn't solve the namespace conflict issue mentioned there)