### PR TITLE
Fix AbstractInputStream#gets to not assume `a_sep_string` will appear…

### DIFF
--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -82,9 +82,14 @@ module Zip
           @output_buffer << produce_input
           over_limit = (number_of_bytes && @output_buffer.bytesize >= number_of_bytes)
         end
-        sep_index = [match_index + a_sep_string.bytesize, number_of_bytes || @output_buffer.bytesize].min
-        @pos += sep_index
-        @output_buffer.slice!(0...sep_index)
+        if over_limit && match_index.nil?
+          @pos += number_of_bytes
+          @output_buffer.slice!(0...number_of_bytes)
+        else
+          sep_index = [match_index + a_sep_string.bytesize, number_of_bytes || @output_buffer.bytesize].min
+          @pos += sep_index
+          @output_buffer.slice!(0...sep_index)
+        end
       end
 
       def ungetc(byte)


### PR DESCRIPTION
The `AbstractInputStream#gets` has logic to check if the number of bytes within the `@output_buffer` are over the limit then sets `over_limit`. It seems that if a separator was passed in along with the number of bytes the code assumes the separator will appear within the bytes read. 

This was picked up when streaming a CSV out of a ZIP where the CSV passes the `a_sep_string` as `\n` and the number of bytes as `8192` and the file contains a single column value that is longer than `8192` bytes

I made a change that if the separator wasn't found and we are above the limit it will return up to the number of bytes and increase the `@pos` by that amount. 

(This is my first pull request please let me know if I need to do anything else)