### PR TITLE
Support passing decrypter to encrypted entry via get_input_stream

### DIFF
--- a/lib/zip/entry.rb
+++ b/lib/zip/entry.rb
@@ -638,8 +638,9 @@ module Zip
     end
 
     # Returns an IO like object for the given ZipEntry.
+    # Optional decrypter can be provided for an encrypted entry
     # Warning: may behave weird with symlinks.
-    def get_input_stream(&block)
+    def get_input_stream(decrypter: nil, &block)
       if ftype == :directory
         yield ::Zip::NullInputStream if block
         ::Zip::NullInputStream
@@ -656,7 +657,7 @@ module Zip
           raise "unknown @file_type #{ftype}"
         end
       else
-        zis = ::Zip::InputStream.new(@zipfile, offset: local_header_offset)
+        zis = ::Zip::InputStream.new(@zipfile, offset: local_header_offset, decrypter: decrypter)
         zis.instance_variable_set(:@complete_entry, self)
         zis.get_next_entry
         if block

--- a/test/encryption_test.rb
+++ b/test/encryption_test.rb
@@ -112,6 +112,26 @@ class EncryptionTest < Minitest::Test
     end
   end
 
+  def test_aes_256_entry_decrypt
+    zip_file = Zip::File.new("#{DATA_DIR}/#{AES_256_ZIP_TEST_FILE}")
+    entries = zip_file.entries
+    assert_equal 2, entries.size # Ensure central directory can be read when zip is encrypted
+
+    decrypter = Zip::AESDecrypter.new('password', Zip::AESEncryption::STRENGTH_256_BIT)
+
+    [INPUT_FILE3, INPUT_FILE4].each do |entry_name|
+      entry = zip_file.find_entry(entry_name)
+      assert entry
+      assert entry.encrypted?
+
+      entry.get_input_stream(decrypter: decrypter) do |entry_stream|
+        input_file_stream = ::File.open("#{DATA_DIR}/#{entry_name}", 'rb')
+        assert_equal input_file_stream.read(2), entry_stream.read(2)
+        assert_equal input_file_stream.read, entry_stream.read
+      end
+    end
+  end
+
   def test_aes_decrypt_keka
     Zip::InputStream.open(
       "#{DATA_DIR}/#{AES_KEKA_ZIP_TEST_FILE}",


### PR DESCRIPTION
This adds the ability for someone to pass a decrypter to an encrypted entry easily.

If someone were to grab a Zip::Entry from the CentralDirectory this will still allow them to easy pass a decrypter to the created InputStream for easy adhoc decryption. 

Currently if a zip is encrypted we can only access the decrypted entries via the InputStream and it doesn't not integrate with the CentralDirectory meaning we would need to read through the entries sequentially. With this we can have a bit of both worlds. Allow random entry access and decrypt them if they are encrypted.

I was looking into potentially passing the decrypter to a Zip::File and then it passes it to the CentralDirectory that will initialize entries with a `@decrypter` and then they would use that for the InputStream but this be a larger rework and might be completely unnecessary. 