### PR TITLE
Support setting the encoding of the input stream

### DIFF
--- a/lib/zip/input_stream.rb
+++ b/lib/zip/input_stream.rb
@@ -51,8 +51,9 @@ module Zip
     #
     # @param context [String||IO||StringIO] file path or IO/StringIO object
     # @param offset [Integer] offset in the IO/StringIO
-    def initialize(context, offset: 0, decrypter: nil)
-      super()
+    # @param encoding [Encoding] encoding of the decompressed stream
+    def initialize(context, offset: 0, decrypter: nil, encoding: Encoding::ASCII_8BIT)
+      super(encoding: encoding)
       @archive_io = get_io(context, offset)
       @decompressor = ::Zip::NullDecompressor
       @decrypter = decrypter
@@ -107,7 +108,7 @@ module Zip
       output = produce_input(maxlen)
 
       if out_string.nil?
-        output.force_encoding(Encoding::ASCII_8BIT)
+        output.force_encoding(@encoding)
       else
         encoding = out_string.encoding
         out_string.replace(output).force_encoding(encoding)

--- a/lib/zip/input_stream.rb
+++ b/lib/zip/input_stream.rb
@@ -51,9 +51,10 @@ module Zip
     #
     # @param context [String||IO||StringIO] file path or IO/StringIO object
     # @param offset [Integer] offset in the IO/StringIO
-    # @param encoding [Encoding] encoding of the decompressed stream
-    def initialize(context, offset: 0, decrypter: nil, encoding: Encoding::ASCII_8BIT)
-      super(encoding: encoding)
+    # This method also accepts the standard IO encoding options:
+    # `external_encoding:`, `internal_encoding:` and `encoding:`.
+    def initialize(context, offset: 0, decrypter: nil, **opts)
+      super(**opts)
       @archive_io = get_io(context, offset)
       @decompressor = ::Zip::NullDecompressor
       @decrypter = decrypter
@@ -108,7 +109,7 @@ module Zip
       output = produce_input(maxlen)
 
       if out_string.nil?
-        output.force_encoding(@encoding)
+        output.force_encoding(@internal_encoding || @external_encoding)
       else
         encoding = out_string.encoding
         out_string.replace(output).force_encoding(encoding)
@@ -126,8 +127,8 @@ module Zip
       # Same as #initialize but if a block is passed the opened
       # stream is passed to the block and closed when the block
       # returns.
-      def open(filename_or_io, offset: 0, decrypter: nil)
-        zio = new(filename_or_io, offset: offset, decrypter: decrypter)
+      def open(filename_or_io, offset: 0, decrypter: nil, **opts)
+        zio = new(filename_or_io, offset: offset, decrypter: decrypter, **opts)
         return zio unless block_given?
 
         begin

--- a/lib/zip/ioextras.rb
+++ b/lib/zip/ioextras.rb
@@ -21,18 +21,11 @@ module Zip
         end
       end
     end
-
-    # Implements kind_of? in order to pretend to be an IO object
-    module FakeIO # :nodoc:
-      def kind_of?(object)
-        object == IO || super
-      end
-    end
   end
 end
 
-require 'zip/ioextras/abstract_input_stream'
-require 'zip/ioextras/abstract_output_stream'
+require_relative 'ioextras/abstract_input_stream'
+require_relative 'ioextras/abstract_output_stream'
 
 # Copyright (C) 2002-2004 Thomas Sondergaard
 # rubyzip is free software; you can redistribute it and/or

--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -220,7 +220,7 @@ module Zip
       # Sets the forced encoding for the decompressed
       # (and possibly decrypted) data stream. Follows the IO#set_encoding
       # interface, hence the non-standard method name.
-      def set_encoding(encoding) # rubocop:disable Naming/AccessorMethodName
+      def set_encoding(encoding)
         @encoding = encoding
       end
     end

--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'fake_io'
+
 module Zip
   module IOExtras # :nodoc:
     # Implements many of the convenience methods of IO

--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -9,11 +9,17 @@ module Zip
       include Enumerable
       include FakeIO
 
-      def initialize # :nodoc:
-        super
+      # Creates a new input stream wrapper.
+      #
+      # `encoding` sets the forced encoding used for strings returned by
+      # #read, #gets, and related methods. If `nil`, defaults to
+      # `Encoding::ASCII_8BIT`.
+      def initialize(encoding: nil)
+        super()
         @lineno        = 0
         @pos           = 0
         @output_buffer = +''.b
+        @encoding      = encoding || Encoding::ASCII_8BIT
       end
 
       # Returns (or sets) the current line number in the decompressed
@@ -24,6 +30,10 @@ module Zip
       # Returns the current position (in bytes) in the decompressed (possibly
       # decrypted) data stream.
       attr_reader :pos
+
+      # Returns the forced encoding of the decompressed
+      # (and possibly decrypted) data stream
+      attr_reader :encoding
 
       # Reads bytes from the stream decompressed (possibly decrypted) data
       # stream. If `maxlen` is `nil`, reads all bytes; otherwise, reads up to
@@ -60,7 +70,7 @@ module Zip
         @pos += tbuf.length
 
         if out_string.nil?
-          tbuf.force_encoding(Encoding::ASCII_8BIT)
+          tbuf.force_encoding(@encoding)
         else
           encoding = out_string.encoding
           out_string.replace(tbuf).force_encoding(encoding)
@@ -133,7 +143,7 @@ module Zip
 
             @lineno = @lineno.next
             @pos += @output_buffer.bytesize
-            return @output_buffer.slice!(0..)
+            return @output_buffer.slice!(0..).force_encoding(@encoding)
           end
 
           buffer_index = [buffer_index, @output_buffer.bytesize - sep.bytesize].max
@@ -144,7 +154,8 @@ module Zip
         cut_index = sep_index ? [sep_index + sep.bytesize, limit].min : limit
         @lineno = @lineno.next
         @pos += cut_index
-        chomp ? @output_buffer.slice!(0, cut_index).chomp(sep) : @output_buffer.slice!(0, cut_index)
+        data = chomp ? @output_buffer.slice!(0, cut_index).chomp(sep) : @output_buffer.slice!(0, cut_index)
+        data&.force_encoding(@encoding)
       end
 
       def ungetc(byte) # :nodoc:
@@ -205,6 +216,13 @@ module Zip
 
       # Alias for compatibility. Remove for version 4.
       alias eof eof? # :nodoc:
+
+      # Sets the forced encoding for the decompressed
+      # (and possibly decrypted) data stream. Follows the IO#set_encoding
+      # interface, hence the non-standard method name.
+      def set_encoding(encoding) # rubocop:disable Naming/AccessorMethodName
+        @encoding = encoding
+      end
     end
   end
 end

--- a/lib/zip/ioextras/abstract_input_stream.rb
+++ b/lib/zip/ioextras/abstract_input_stream.rb
@@ -13,15 +13,13 @@ module Zip
 
       # Creates a new input stream wrapper.
       #
-      # `encoding` sets the forced encoding used for strings returned by
-      # #read, #gets, and related methods. If `nil`, defaults to
-      # `Encoding::ASCII_8BIT`.
-      def initialize(encoding: nil)
-        super()
+      # This method accepts the standard IO encoding options:
+      # `external_encoding:`, `internal_encoding:` and `encoding:`.
+      def initialize(**opts)
+        super
         @lineno        = 0
         @pos           = 0
         @output_buffer = +''.b
-        @encoding      = encoding || Encoding::ASCII_8BIT
       end
 
       # Returns (or sets) the current line number in the decompressed
@@ -33,10 +31,6 @@ module Zip
       # decrypted) data stream.
       attr_reader :pos
 
-      # Returns the forced encoding of the decompressed
-      # (and possibly decrypted) data stream
-      attr_reader :encoding
-
       # Reads bytes from the stream decompressed (possibly decrypted) data
       # stream. If `maxlen` is `nil`, reads all bytes; otherwise, reads up to
       # `maxlen` bytes. If `maxlen` is zero, returns an empty string.
@@ -45,7 +39,7 @@ module Zip
       # containing the bytes read. The string's encoding is the unchanged
       # encoding of `out_string`, if `out_string` is given; `ASCII-8BIT`,
       # otherwise.
-      def read(maxlen = nil, out_string = nil) # rubocop:disable Metrics/PerceivedComplexity
+      def read(maxlen = nil, out_string = nil) # rubocop:disable Metrics/PerceivedComplexity,Metrics/CyclomaticComplexity
         return (maxlen.nil? || maxlen.zero? ? '' : nil) if eof?
 
         tbuf = if @output_buffer.bytesize > 0
@@ -72,7 +66,7 @@ module Zip
         @pos += tbuf.length
 
         if out_string.nil?
-          tbuf.force_encoding(@encoding)
+          tbuf.force_encoding(@internal_encoding || @external_encoding)
         else
           encoding = out_string.encoding
           out_string.replace(tbuf).force_encoding(encoding)
@@ -121,7 +115,7 @@ module Zip
       #
       # Optional keyword argument `chomp` specifies whether line separators
       # are to be omitted.
-      def gets(sep = $INPUT_RECORD_SEPARATOR, limit = nil, chomp: false)
+      def gets(sep = $INPUT_RECORD_SEPARATOR, limit = nil, chomp: false) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
         if sep.nil?
           return nil if eof?
 
@@ -136,6 +130,8 @@ module Zip
           sep = "#{$INPUT_RECORD_SEPARATOR}#{$INPUT_RECORD_SEPARATOR}"
         end
 
+        encoding = @internal_encoding || @external_encoding
+
         buffer_index = 0
         while (sep_index = @output_buffer.index(sep, buffer_index)).nil?
           break if limit && @output_buffer.bytesize >= limit
@@ -145,7 +141,7 @@ module Zip
 
             @lineno = @lineno.next
             @pos += @output_buffer.bytesize
-            return @output_buffer.slice!(0..).force_encoding(@encoding)
+            return @output_buffer.slice!(0..).force_encoding(encoding)
           end
 
           buffer_index = [buffer_index, @output_buffer.bytesize - sep.bytesize].max
@@ -156,8 +152,9 @@ module Zip
         cut_index = sep_index ? [sep_index + sep.bytesize, limit].min : limit
         @lineno = @lineno.next
         @pos += cut_index
-        data = chomp ? @output_buffer.slice!(0, cut_index).chomp(sep) : @output_buffer.slice!(0, cut_index)
-        data&.force_encoding(@encoding)
+        data = @output_buffer.slice!(0, cut_index)
+        data&.chomp!(sep) if chomp
+        data&.force_encoding(encoding)
       end
 
       def ungetc(byte) # :nodoc:
@@ -218,13 +215,6 @@ module Zip
 
       # Alias for compatibility. Remove for version 4.
       alias eof eof? # :nodoc:
-
-      # Sets the forced encoding for the decompressed
-      # (and possibly decrypted) data stream. Follows the IO#set_encoding
-      # interface, hence the non-standard method name.
-      def set_encoding(encoding)
-        @encoding = encoding
-      end
     end
   end
 end

--- a/lib/zip/ioextras/abstract_output_stream.rb
+++ b/lib/zip/ioextras/abstract_output_stream.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'fake_io'
+
 module Zip
   module IOExtras # :nodoc:
     # Implements many of the output convenience methods of IO.

--- a/lib/zip/ioextras/fake_io.rb
+++ b/lib/zip/ioextras/fake_io.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Zip
+  module IOExtras # :nodoc:
+    # Implements kind_of? in order to pretend to be an IO object
+    module FakeIO # :nodoc:
+      def kind_of?(object)
+        object == IO || super
+      end
+    end
+  end
+end

--- a/lib/zip/ioextras/fake_io.rb
+++ b/lib/zip/ioextras/fake_io.rb
@@ -16,6 +16,20 @@ module Zip
         @external_encoding = Encoding::ASCII_8BIT
       end
 
+      def set_encoding(ext_enc, int_enc = nil)
+        if ext_enc.kind_of?(String) && ext_enc.include?(':')
+          _ext_enc, int_enc = ext_enc.split(':', 2)
+        end
+
+        begin
+          @internal_encoding = Encoding.find(int_enc) if int_enc
+        rescue ArgumentError
+          warn "warning: Unsupported encoding #{int_enc} ignored"
+        end
+
+        @external_encoding = Encoding::ASCII_8BIT
+      end
+
       # Implement kind_of? in order to pretend to be an IO object.
       def kind_of?(object)
         object == IO || super

--- a/lib/zip/ioextras/fake_io.rb
+++ b/lib/zip/ioextras/fake_io.rb
@@ -2,8 +2,21 @@
 
 module Zip
   module IOExtras # :nodoc:
-    # Implements kind_of? in order to pretend to be an IO object
     module FakeIO # :nodoc:
+      attr_reader :external_encoding, :internal_encoding
+
+      def initialize(**opts)
+        @internal_encoding = Encoding.find(opts[:internal_encoding]) if opts[:internal_encoding]
+
+        if opts[:encoding].kind_of?(String)
+          _ext, int = opts[:encoding].split(':', 2)
+          @internal_encoding = Encoding.find(int) unless @internal_encoding || int.nil?
+        end
+
+        @external_encoding = Encoding::ASCII_8BIT
+      end
+
+      # Implement kind_of? in order to pretend to be an IO object.
       def kind_of?(object)
         object == IO || super
       end

--- a/lib/zip/output_stream.rb
+++ b/lib/zip/output_stream.rb
@@ -29,8 +29,8 @@ module Zip
 
     # Opens the indicated zip file. If a file with that name already
     # exists it will be overwritten.
-    def initialize(file_name, stream: false, encrypter: nil, suppress_extra_fields: false)
-      super()
+    def initialize(file_name, stream: false, encrypter: nil, suppress_extra_fields: false, **opts)
+      super(**opts)
       @file_name = file_name
       @output_stream = if stream
                          iostream = Zip::RUNNING_ON_WINDOWS ? @file_name : @file_name.dup
@@ -52,27 +52,28 @@ module Zip
       # Same as #initialize but if a block is passed the opened
       # stream is passed to the block and closed when the block
       # returns.
-      def open(file_name, encrypter: nil, suppress_extra_fields: false)
+      def open(file_name, encrypter: nil, suppress_extra_fields: false, **opts)
         unless block_given?
           return new(
             file_name,
             encrypter:             encrypter,
-            suppress_extra_fields: suppress_extra_fields
+            suppress_extra_fields: suppress_extra_fields,
+            **opts
           )
         end
 
         zos = new(file_name, stream: false, encrypter: encrypter,
-                  suppress_extra_fields: suppress_extra_fields)
+                  suppress_extra_fields: suppress_extra_fields, **opts)
         yield zos
       ensure
         zos.close if zos
       end
 
       # Same as #open but writes to a filestream instead
-      def write_buffer(io = ::StringIO.new, encrypter: nil, suppress_extra_fields: false)
+      def write_buffer(io = ::StringIO.new, encrypter: nil, suppress_extra_fields: false, **opts)
         io.binmode if io.respond_to?(:binmode)
         zos = new(io, stream: true, encrypter: encrypter,
-                  suppress_extra_fields: suppress_extra_fields)
+                  suppress_extra_fields: suppress_extra_fields, **opts)
         yield zos
         zos.close_buffer
       end

--- a/test/input_stream_test.rb
+++ b/test/input_stream_test.rb
@@ -378,4 +378,12 @@ class ZipInputStreamTest < Minitest::Test
       assert_equal(Encoding::ASCII_8BIT, buffer.encoding)
     end
   end
+
+  def test_set_encoding
+    Zip::InputStream.open(TestZipFile::TEST_ZIP2.zip_name) do |zis|
+      zis.set_encoding(Encoding::BINARY)
+      zis.get_next_entry
+      assert_equal(Encoding::BINARY, zis.readline.encoding)
+    end
+  end
 end

--- a/test/input_stream_test.rb
+++ b/test/input_stream_test.rb
@@ -380,8 +380,8 @@ class ZipInputStreamTest < Minitest::Test
   end
 
   def test_set_encoding
-    Zip::InputStream.open(TestZipFile::TEST_ZIP2.zip_name) do |zis|
-      zis.set_encoding(Encoding::BINARY)
+    Zip::InputStream.open(TestZipFile::TEST_ZIP2.zip_name, internal_encoding: Encoding::UTF_8) do |zis|
+      zis.set_encoding(Encoding::UTF_8, Encoding::BINARY)
       zis.get_next_entry
       assert_equal(Encoding::BINARY, zis.readline.encoding)
     end

--- a/test/ioextras/abstract_input_stream_test.rb
+++ b/test/ioextras/abstract_input_stream_test.rb
@@ -23,8 +23,8 @@ class AbstractInputStreamTest < Minitest::Test
   class TestAbstractInputStream
     include ::Zip::IOExtras::AbstractInputStream
 
-    def initialize(string)
-      super()
+    def initialize(string, encoding: nil)
+      super(encoding: encoding)
       @contents = string
       @read_ptr = 0
     end
@@ -115,6 +115,17 @@ class AbstractInputStreamTest < Minitest::Test
     assert_equal(Encoding::ASCII_8BIT, result.encoding)
   end
 
+  def test_read_with_utf8_encoding
+    io = TestAbstractInputStream.new(TEST_STRING, encoding: Encoding::UTF_8)
+    assert_equal(Encoding::UTF_8, io.read&.encoding)
+  end
+
+  def test_read_with_encoding_and_outstring
+    io = TestAbstractInputStream.new(TEST_STRING, encoding: Encoding::UTF_8)
+    out_string = +''.b
+    assert_equal(io.read(5, out_string).encoding, Encoding::BINARY)
+  end
+
   def test_gets
     io = line_tests
 
@@ -201,6 +212,11 @@ class AbstractInputStreamTest < Minitest::Test
     assert_nil(io.gets(8))
   end
 
+  def test_gets_with_utf8_encoding
+    io = TestAbstractInputStream.new(TEST_STRING, encoding: Encoding::UTF_8)
+    assert_equal(io.gets&.encoding, Encoding::UTF_8)
+  end
+
   def test_each
     io = TestAbstractInputStream.new(TEST_STRING)
 
@@ -285,6 +301,15 @@ class AbstractInputStreamTest < Minitest::Test
     assert_equal(3, io.lineno)
   end
 
+  def test_readlines_with_utf8_encoding
+    io = TestAbstractInputStream.new(TEST_STRING, encoding: Encoding::UTF_8)
+    lines = io.readlines
+    assert_equal(TEST_LINES, lines)
+    lines.each do |line|
+      assert_equal(Encoding::UTF_8, line.encoding)
+    end
+  end
+
   def test_readlines_with_nil_separator
     io = TestAbstractInputStream.new(TEST_STRING)
 
@@ -330,6 +355,19 @@ class AbstractInputStreamTest < Minitest::Test
 
     assert_predicate(io, :eof?)
     assert_raises(EOFError) { io.readline(8) }
+  end
+
+  def test_readline_with_utf8_encoding
+    io = TestAbstractInputStream.new(TEST_STRING, encoding: Encoding::UTF_8)
+    assert_equal(io.readline.encoding, Encoding::UTF_8)
+  end
+
+  def test_set_encoding
+    io = TestAbstractInputStream.new(TEST_STRING)
+    assert_equal(Encoding::ASCII_8BIT, io.read(1).encoding)
+    io.set_encoding(Encoding::UTF_8)
+    assert_equal(Encoding::UTF_8, io.read(1).encoding)
+    assert_equal(Encoding::UTF_8, io.gets&.encoding)
   end
 
   private

--- a/test/ioextras/abstract_input_stream_test.rb
+++ b/test/ioextras/abstract_input_stream_test.rb
@@ -23,8 +23,8 @@ class AbstractInputStreamTest < Minitest::Test
   class TestAbstractInputStream
     include ::Zip::IOExtras::AbstractInputStream
 
-    def initialize(string, encoding: nil)
-      super(encoding: encoding)
+    def initialize(string, **opts)
+      super(**opts)
       @contents = string
       @read_ptr = 0
     end
@@ -116,12 +116,12 @@ class AbstractInputStreamTest < Minitest::Test
   end
 
   def test_read_with_utf8_encoding
-    io = TestAbstractInputStream.new(TEST_STRING, encoding: Encoding::UTF_8)
+    io = TestAbstractInputStream.new(TEST_STRING, internal_encoding: Encoding::UTF_8)
     assert_equal(Encoding::UTF_8, io.read&.encoding)
   end
 
   def test_read_with_encoding_and_outstring
-    io = TestAbstractInputStream.new(TEST_STRING, encoding: Encoding::UTF_8)
+    io = TestAbstractInputStream.new(TEST_STRING, internal_encoding: Encoding::UTF_8)
     out_string = +''.b
     assert_equal(io.read(5, out_string).encoding, Encoding::BINARY)
   end
@@ -213,7 +213,7 @@ class AbstractInputStreamTest < Minitest::Test
   end
 
   def test_gets_with_utf8_encoding
-    io = TestAbstractInputStream.new(TEST_STRING, encoding: Encoding::UTF_8)
+    io = TestAbstractInputStream.new(TEST_STRING, internal_encoding: Encoding::UTF_8)
     assert_equal(io.gets&.encoding, Encoding::UTF_8)
   end
 
@@ -302,7 +302,7 @@ class AbstractInputStreamTest < Minitest::Test
   end
 
   def test_readlines_with_utf8_encoding
-    io = TestAbstractInputStream.new(TEST_STRING, encoding: Encoding::UTF_8)
+    io = TestAbstractInputStream.new(TEST_STRING, internal_encoding: Encoding::UTF_8)
     lines = io.readlines
     assert_equal(TEST_LINES, lines)
     lines.each do |line|
@@ -358,14 +358,14 @@ class AbstractInputStreamTest < Minitest::Test
   end
 
   def test_readline_with_utf8_encoding
-    io = TestAbstractInputStream.new(TEST_STRING, encoding: Encoding::UTF_8)
+    io = TestAbstractInputStream.new(TEST_STRING, internal_encoding: Encoding::UTF_8)
     assert_equal(io.readline.encoding, Encoding::UTF_8)
   end
 
   def test_set_encoding
     io = TestAbstractInputStream.new(TEST_STRING)
     assert_equal(Encoding::ASCII_8BIT, io.read(1).encoding)
-    io.set_encoding(Encoding::UTF_8)
+    io.set_encoding(Encoding::ASCII_8BIT, Encoding::UTF_8)
     assert_equal(Encoding::UTF_8, io.read(1).encoding)
     assert_equal(Encoding::UTF_8, io.gets&.encoding)
   end

--- a/test/ioextras/fake_io_test.rb
+++ b/test/ioextras/fake_io_test.rb
@@ -18,4 +18,106 @@ class FakeIOTest < Minitest::Test
     assert(!obj.kind_of?(Integer))
     assert(!obj.kind_of?(String))
   end
+
+  def test_initialize_with_no_encoding
+    obj = FakeIOUsingClass.new
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_nil(obj.internal_encoding)
+  end
+
+  def test_initialize_with_encoding
+    obj = FakeIOUsingClass.new(encoding: 'UTF-8:UTF-16LE')
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_equal(Encoding::UTF_16LE, obj.internal_encoding)
+  end
+
+  def test_initialize_with_bad_encoding
+    assert_raises(ArgumentError) do
+      FakeIOUsingClass.new(encoding: 'UTF-8:BAD_ENCODING')
+    end
+  end
+
+  def test_initialize_with_encoding_just_external
+    obj = FakeIOUsingClass.new(encoding: 'UTF-8')
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_nil(obj.internal_encoding)
+  end
+
+  def test_initialize_with_external_encoding
+    obj = FakeIOUsingClass.new(external_encoding: Encoding::UTF_8)
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_nil(obj.internal_encoding)
+  end
+
+  def test_initialize_with_internal_encoding
+    obj = FakeIOUsingClass.new(internal_encoding: Encoding::UTF_16LE)
+
+    assert_equal(Encoding::UTF_16LE, obj.internal_encoding)
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+  end
+
+  def test_initialize_with_external_encoding_as_string
+    obj = FakeIOUsingClass.new(external_encoding: 'UTF-8')
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_nil(obj.internal_encoding)
+  end
+
+  def test_initialize_with_internal_encoding_as_string
+    obj = FakeIOUsingClass.new(internal_encoding: 'UTF-16LE')
+
+    assert_equal(Encoding::UTF_16LE, obj.internal_encoding)
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+  end
+
+  def test_initialize_with_bad_external_encoding_string
+    # assert_raises(ArgumentError) do
+    FakeIOUsingClass.new(external_encoding: 'BAD_ENCODING')
+    # end
+  end
+
+  def test_initialize_with_bad_internal_encoding_string
+    assert_raises(ArgumentError) do
+      FakeIOUsingClass.new(internal_encoding: 'BAD_ENCODING')
+    end
+  end
+
+  def test_initialize_with_internal_and_external_encoding
+    obj = FakeIOUsingClass.new(external_encoding: Encoding::UTF_8, internal_encoding: Encoding::UTF_16LE)
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_equal(Encoding::UTF_16LE, obj.internal_encoding)
+  end
+
+  def test_initialize_with_internal_and_external_encoding_as_strings
+    obj = FakeIOUsingClass.new(external_encoding: 'UTF-8', internal_encoding: 'UTF-16LE')
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_equal(Encoding::UTF_16LE, obj.internal_encoding)
+  end
+
+  def test_initialize_with_encoding_and_external_encoding
+    obj = FakeIOUsingClass.new(encoding: 'UTF-8:UTF-16LE', external_encoding: Encoding::ISO_8859_1)
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_equal(Encoding::UTF_16LE, obj.internal_encoding)
+  end
+
+  def test_initialize_with_encoding_and_internal_encoding
+    obj = FakeIOUsingClass.new(encoding: 'UTF-8:UTF-16LE', internal_encoding: Encoding::UTF_32LE)
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_equal(Encoding::UTF_32LE, obj.internal_encoding)
+  end
+
+  def test_initialize_with_all_encoding_options
+    obj = FakeIOUsingClass.new(encoding: 'UTF-8:UTF-16LE', external_encoding: Encoding::ISO_8859_1, internal_encoding: Encoding::UTF_32LE)
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_equal(Encoding::UTF_32LE, obj.internal_encoding)
+  end
 end

--- a/test/ioextras/fake_io_test.rb
+++ b/test/ioextras/fake_io_test.rb
@@ -120,4 +120,66 @@ class FakeIOTest < Minitest::Test
     assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
     assert_equal(Encoding::UTF_32LE, obj.internal_encoding)
   end
+
+  def test_set_encoding_with_external_encoding
+    obj = FakeIOUsingClass.new
+    obj.set_encoding(Encoding::UTF_8)
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_nil(obj.internal_encoding)
+  end
+
+  def test_set_encoding_with_external_encoding_as_string
+    obj = FakeIOUsingClass.new
+    obj.set_encoding('UTF-8')
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_nil(obj.internal_encoding)
+  end
+
+  def test_set_encoding_with_bad_external_encoding
+    obj = FakeIOUsingClass.new
+
+    assert_silent do
+      obj.set_encoding('BAD_ENCODING')
+    end
+  end
+
+  def test_set_encoding_with_external_and_internal_encoding
+    obj = FakeIOUsingClass.new
+    obj.set_encoding(Encoding::UTF_8, Encoding::UTF_16LE)
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_equal(Encoding::UTF_16LE, obj.internal_encoding)
+  end
+
+  def test_set_encoding_with_external_and_internal_encoding_as_strings
+    obj = FakeIOUsingClass.new
+    obj.set_encoding('UTF-8', 'UTF-16LE')
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_equal(Encoding::UTF_16LE, obj.internal_encoding)
+  end
+
+  def test_set_encoding_with_bad_internal_encoding
+    obj = FakeIOUsingClass.new
+    assert_output('', /warning: Unsupported encoding BAD_ENCODING ignored/) do
+      obj.set_encoding(Encoding::UTF_8, 'BAD_ENCODING')
+    end
+  end
+
+  def test_set_encoding_with_external_and_internal_encoding_as_single_string
+    obj = FakeIOUsingClass.new
+    obj.set_encoding('UTF-8:UTF-16LE')
+
+    assert_equal(Encoding::ASCII_8BIT, obj.external_encoding)
+    assert_equal(Encoding::UTF_16LE, obj.internal_encoding)
+  end
+
+  def test_set_encoding_with_bad_external_and_internal_encoding_as_single_string
+    obj = FakeIOUsingClass.new
+    assert_output('', /warning: Unsupported encoding BAD_ENCODING! ignored/) do
+      obj.set_encoding('BAD_ENCODING:BAD_ENCODING!')
+    end
+  end
 end

--- a/test/ioextras/fake_io_test.rb
+++ b/test/ioextras/fake_io_test.rb
@@ -2,11 +2,11 @@
 
 require_relative '../test_helper'
 
-require 'zip/ioextras'
+require 'zip/ioextras/fake_io'
 
 class FakeIOTest < Minitest::Test
   class FakeIOUsingClass
-    include ::Zip::IOExtras::FakeIO
+    include Zip::IOExtras::FakeIO
   end
 
   def test_kind_of?

--- a/test/output_stream_test.rb
+++ b/test/output_stream_test.rb
@@ -15,6 +15,10 @@ class ZipOutputStreamTest < Minitest::Test
 
   def test_new
     zos = ::Zip::OutputStream.new(TEST_ZIP.zip_name)
+
+    assert_equal(Encoding::ASCII_8BIT, zos.external_encoding)
+    assert_nil(zos.internal_encoding)
+
     zos.comment = TEST_ZIP.comment
     write_test_zip(zos)
     zos.close
@@ -23,6 +27,9 @@ class ZipOutputStreamTest < Minitest::Test
 
   def test_open
     ::Zip::OutputStream.open(TEST_ZIP.zip_name) do |zos|
+      assert_equal(Encoding::ASCII_8BIT, zos.external_encoding)
+      assert_nil(zos.internal_encoding)
+
       zos.comment = TEST_ZIP.comment
       write_test_zip(zos)
     end
@@ -45,6 +52,9 @@ class ZipOutputStreamTest < Minitest::Test
 
   def test_write_buffer
     buffer = ::Zip::OutputStream.write_buffer(::StringIO.new) do |zos|
+      assert_equal(Encoding::ASCII_8BIT, zos.external_encoding)
+      assert_nil(zos.internal_encoding)
+
       zos.comment = TEST_ZIP.comment
       write_test_zip(zos)
     end
@@ -54,6 +64,9 @@ class ZipOutputStreamTest < Minitest::Test
 
   def test_write_buffer_binmode
     buffer = ::Zip::OutputStream.write_buffer(::StringIO.new) do |zos|
+      assert_equal(Encoding::ASCII_8BIT, zos.external_encoding)
+      assert_nil(zos.internal_encoding)
+
       zos.comment = TEST_ZIP.comment
       write_test_zip(zos)
     end


### PR DESCRIPTION
Currently the `AbstractInputStream#read` supports passing an `out_string` to change the encoding of the output. 
But in some cases we are not the ones calling the `read` or `gets` and these are being done inside some parser like `CSV`. In most cases the parser doesn't `force_encode` the output of the input stream and tries to parse on the wrong encoding. 

With this change we can set the encoding when we get the input stream for the zip. So that the data being sent to the parsers will be in the expected encoding.

I tried following a similar pattern I had seen in `StringIO` and `IO` where you can pass the encoding along in the initialize or call `set_encoding` on the stream to change it.