### PR TITLE
Clarify README on storing non-English filenames as UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Zip.continue_on_exists_proc = true
 
 ### Non-ASCII Names
 
-If you want to store non-english names and want to open them on Windows(pre 7) you need to set this option:
+To store non-English filenames as UTF-8 (decoded correctly by Windows 7 or later and other modern tools), set this option:
 
 ```ruby
 Zip.unicode_names = true


### PR DESCRIPTION
Thanks for this useful library!

Fixed the "Non-ASCII Names" section, where the Windows version range was reversed.

`Zip.unicode_names = true` sets the ZIP EFS flag (bit 11), marking filenames as UTF-8. The Windows built-in ZIP handler honors this flag only on Windows 7 or later; earlier versions ignore it. The previous wording (`Windows(pre 7)`) was the opposite of the actual behavior.