### PR TITLE
Clamp DOS date and time to the range the fields can hold

### DIFF
--- a/lib/zip/dos_time.rb
+++ b/lib/zip/dos_time.rb
@@ -16,6 +16,18 @@ module Zip
     # bits 5-8 month (1-12)
     # bits 9-15 year (four digit year minus 1980)
 
+    # The MS-DOS date field is seven bits of "year minus 1980", so only
+    # 1980-01-01 00:00:00 through 2107-12-31 23:59:58 can be represented.
+    # Times outside that are clamped rather than allowed to wrap: the real
+    # time is still carried in the universal time (UT) extra field, but the
+    # DOS fields have to stay in range for readers that only look at those.
+    DOS_EPOCH_YEAR = 1980
+    DOS_MAX_YEAR = 2107
+    DOS_MIN_DATE = 0x0021 # 1980-01-01
+    DOS_MAX_DATE = 0xff9f # 2107-12-31
+    DOS_MIN_TIME = 0x0000 # 00:00:00
+    DOS_MAX_TIME = 0xbf7d # 23:59:58
+
     attr_writer :absolute_time # :nodoc:
 
     def absolute_time?
@@ -25,15 +37,21 @@ module Zip
     end
 
     def to_binary_dos_time
+      return DOS_MIN_TIME if year < DOS_EPOCH_YEAR
+      return DOS_MAX_TIME if year > DOS_MAX_YEAR
+
       (sec / 2) +
         (min << 5) +
         (hour << 11)
     end
 
     def to_binary_dos_date
+      return DOS_MIN_DATE if year < DOS_EPOCH_YEAR
+      return DOS_MAX_DATE if year > DOS_MAX_YEAR
+
       day +
         (month << 5) +
-        ((year - 1980) << 9)
+        ((year - DOS_EPOCH_YEAR) << 9)
     end
 
     # Deprecated. Remove for version 4.

--- a/test/dos_time_test.rb
+++ b/test/dos_time_test.rb
@@ -62,6 +62,35 @@ class DOSTimeTest < Minitest::Test
     assert(dos_time.absolute_time?)
   end
 
+  def test_binary_dos_fields_are_clamped_to_the_representable_range
+    # The DOS date field holds "year - 1980" in seven bits, so only
+    # 1980-01-01 00:00:00 .. 2107-12-31 23:59:58 fits. Out-of-range years
+    # used to wrap, writing a valid-looking but wrong date.
+    assert_equal(0x0021, Zip::DOSTime.local(1980, 1, 1, 0, 0, 0).to_binary_dos_date)
+    assert_equal(0x0000, Zip::DOSTime.local(1980, 1, 1, 0, 0, 0).to_binary_dos_time)
+    assert_equal(0xff9f, Zip::DOSTime.local(2107, 12, 31, 23, 59, 58).to_binary_dos_date)
+    assert_equal(0xbf7d, Zip::DOSTime.local(2107, 12, 31, 23, 59, 58).to_binary_dos_time)
+
+    # below the epoch: clamp to the floor, do not wrap into the future
+    [1970, 1979].each do |year|
+      dos_time = Zip::DOSTime.local(year, 6, 15, 12, 30, 30)
+      assert_equal(0x0021, dos_time.to_binary_dos_date, "year #{year} date")
+      assert_equal(0x0000, dos_time.to_binary_dos_time, "year #{year} time")
+    end
+
+    # above the last representable year: clamp to the ceiling
+    dos_time = Zip::DOSTime.local(2108, 6, 15, 12, 30, 30)
+    assert_equal(0xff9f, dos_time.to_binary_dos_date)
+    assert_equal(0xbf7d, dos_time.to_binary_dos_time)
+
+    # every clamped value still has to fit the 16-bit field
+    [1970, 1979, 1980, 2022, 2107, 2108].each do |year|
+      dos_time = Zip::DOSTime.local(year, 6, 15, 12, 30, 30)
+      assert_includes(0..0xffff, dos_time.to_binary_dos_date, "year #{year}")
+      assert_includes(0..0xffff, dos_time.to_binary_dos_time, "year #{year}")
+    end
+  end
+
   def test_local
     dos_time = Zip::DOSTime.local(2022, 1, 1, 12, 0, 0)
     assert(dos_time.absolute_time?)


### PR DESCRIPTION
## The problem

`to_binary_dos_date` does its arithmetic with no range check, so a year outside what the field can hold wraps into a different, valid-looking date instead of failing or clamping:

```
year        to_binary   packed_v   reads back as
1970            -5087      60449            2098
1979             -479      65057            2107
1980               33         33            1980
2022            21537      21537            2022
2107            65057      65057            2107
2108            65569         33            1980
```

Through the public API, writing an entry with a 1970 mtime:

```
rubyzip reads back:          1970-01-01 00:00:00 +0900
central-dir DOS date field = 60449 -> year 2098

$ unzip -l probe.zip
        2  2106-02-07 06:28   a.txt
```

Pre-1980 timestamps are not exotic — `SOURCE_DATE_EPOCH=0` reproducible builds and files restored from tarballs with epoch times both land there.

## Why it went unnoticed

rubyzip writes the universal time (`UT`) extra field as well and prefers it when reading, so **rubyzip's own round trip returns the original time** and the corruption is invisible from inside the library. Only readers that use the DOS fields see it — `unzip`, Python's `zipfile`, Windows Explorer.

The tests never approach the boundary either: all eleven cases in `test/dos_time_test.rb` use the year 2022, and nothing round-trips `to_binary_dos_date`.

## The contract

The format notes at the top of the file state the field width:

> bits 9-15 year (four digit year minus 1980)
> — `lib/zip/dos_time.rb:17`

Seven bits with a 1980 offset is 1980..2107. `to_binary_dos_date` implements `((year - 1980) << 9)` without honouring it.

## The change

Clamp to the representable range rather than wrapping — `1980-01-01 00:00:00` at the floor, `2107-12-31 23:59:58` at the ceiling. In-range years are untouched.

I picked clamping over raising for two reasons. The real time is still carried in the `UT` extra field, so the DOS fields only need to stay in range for readers that look at them. And clamping is what Info-ZIP writes for a pre-1980 file — measured, same input:

```
$ touch -d "1970-01-01 00:00:00" a.txt && zip -X test.zip a.txt && unzip -l test.zip
        3  1980-01-01 00:00   a.txt
```

After this change rubyzip writes the same thing. (Python's `zipfile` takes the other route and raises `ValueError: ZIP does not support timestamps before 1980`; if you would rather rubyzip refuse than clamp, say so and I will switch it — the important part is that it stops writing a wrong date silently.)

## Tests

`test_binary_dos_fields_are_clamped_to_the_representable_range` covers both boundary years, one year past each end, and asserts every result still fits the 16-bit field.

Verified by reverting only `lib/zip/dos_time.rb` and keeping the test — it fails. Full suite: 412 runs / 2820 assertions before, 413 / 2854 after, 0 failures either way.

## A separate issue found nearby

`Zip::DOSTime.parse_binary_dos_format(0, 0)` raises `ArgumentError: mon out of range` at `lib/zip/dos_time.rb:65`, because a zero DOS date gives `month = 0, day = 0` and goes straight into `Time.local`. Zero DOS timestamps show up in streamed and tool-generated archives, and this is on the read path (`lib/zip/entry.rb:748`). I have not confirmed end-to-end reachability from a crafted archive and have left it out of this PR — happy to open a separate one if it is worth having.

---

*Disclosure: this patch was prepared with AI assistance. The reproduction, the Info-ZIP comparison, the red/green check and the suite runs above were executed against this branch; happy to adjust anything on request.*
