### PR TITLE
Load openssl only when AES encryption is used

### DIFF
--- a/lib/zip/crypto/aes_encryption.rb
+++ b/lib/zip/crypto/aes_encryption.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'openssl'
-
 module Zip
   module AESEncryption # :nodoc:
     VERIFIER_LENGTH = 2
@@ -45,6 +43,11 @@ module Zip
     }.freeze
 
     def initialize(password, strength)
+      # Loaded here rather than at the top of the file so that `require 'zip'`
+      # does not pull in openssl. Only AES-encrypted archives need it, and it
+      # is the single largest cost of loading this library.
+      require 'openssl'
+
       @password = password
       @strength = strength
       @bits = BITS[@strength]

--- a/test/require_test.rb
+++ b/test/require_test.rb
@@ -6,9 +6,17 @@ class RequireTest < Minitest::Test
   # Guards the deferred `require 'openssl'` in Zip::AESEncryption#initialize.
   # These run in a subprocess because the test suite has already loaded
   # openssl by way of the AES tests.
+
+  # Interpreter options set in the environment are inherited by the
+  # subprocess, where they can both add noise to its output and preload
+  # libraries -- either of which invalidates what is measured here. Our own
+  # CI runs the suite with `RUBYOPT=-v`, which makes every subprocess print
+  # its version banner ahead of the script's own output.
+  CLEAN_ENV = { 'RUBYOPT' => nil }.freeze
+
   def subprocess(script)
     lib = File.expand_path('../lib', __dir__)
-    IO.popen([RbConfig.ruby, '-I', lib, '-e', script], &:read)
+    IO.popen(CLEAN_ENV, [RbConfig.ruby, '-I', lib, '-e', script], &:read)
   end
 
   def openssl_loaded

--- a/test/require_test.rb
+++ b/test/require_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative 'test_helper'
+
+class RequireTest < Minitest::Test
+  # Guards the deferred `require 'openssl'` in Zip::AESEncryption#initialize.
+  # These run in a subprocess because the test suite has already loaded
+  # openssl by way of the AES tests.
+  def subprocess(script)
+    lib = File.expand_path('../lib', __dir__)
+    IO.popen([RbConfig.ruby, '-I', lib, '-e', script], &:read)
+  end
+
+  def openssl_loaded
+    "$LOADED_FEATURES.any? { |f| File.basename(f) == 'openssl.rb' }"
+  end
+
+  def test_requiring_zip_does_not_load_openssl
+    assert_equal 'false', subprocess("require 'zip'; print #{openssl_loaded}")
+  end
+
+  def test_creating_an_aes_decrypter_loads_openssl
+    script = "require 'zip'; " \
+             "Zip::AESDecrypter.new('pwd', Zip::AESEncryption::STRENGTH_256_BIT); " \
+             "print #{openssl_loaded}"
+
+    assert_equal 'true', subprocess(script)
+  end
+
+  def test_aes_decryption_still_works_without_an_eager_require
+    script = "require 'zip'; " \
+             "d = Zip::AESDecrypter.new('password', Zip::AESEncryption::STRENGTH_128_BIT); " \
+             "d.reset!([127, 254, 117, 113, 255, 209, 171, 131, 179, 106].pack('C*')); " \
+             "print d.decrypt([34, 33, 106].map(&:chr).join) == [75, 4, 0].pack('C*')"
+
+    assert_equal 'true', subprocess(script)
+  end
+end


### PR DESCRIPTION
## Problem

`lib/zip/crypto/aes_encryption.rb` requires `openssl` at the top of the file, and `zip.rb` requires that file unconditionally. `openssl` in turn pulls in `ipaddr` and `socket`, so **every** `require 'zip'` pays for the whole TLS stack — even though only AES-encrypted archives need it.

It is by a wide margin the single largest cost of loading rubyzip:

```
   53.00  zip
    7.71    tempfile
   23.02    zip/crypto/aes_encryption      <-- 43% of total
   22.72      openssl
    5.63        openssl.so
    5.08        ipaddr
    3.44          socket
```

## Fix

Every `OpenSSL` reference in the file sits inside `AESDecrypter#reset!` (`OpenSSL::KDF.pbkdf2_hmac`, `OpenSSL::Cipher::AES`, `OpenSSL::HMAC`, `OpenSSL::Digest`). The constants other files read — `AESEncryption::VERSIONS` from `entry.rb` and `AESEncryption::AUTHENTICATION_CODE_LENGTH` from `input_stream.rb` — are plain Ruby and need nothing loaded.

Moving the require into `AESEncryption#initialize` covers every path: `AESDecrypter` is the only includer of the module, and `reset!` cannot be reached without constructing one first.

## Measurements

Ruby 4.0.6 (arm64-darwin), best of seven runs:

| | `require 'zip'` | files loaded |
|---|---:|---:|
| before | 45.69 ms | 75 |
| after | 24.67 ms | 54 |
| | **−21.02 ms (46%)** | **−21** |

Confirmed directly:

```ruby
require 'zip'
# openssl loaded? => false
Zip::AESDecrypter.new('pw', Zip::AESEncryption::STRENGTH_256_BIT)
# openssl loaded? => true
```

## Tests

`bundle exec rake test`: **415 runs, 0 failures** (was 412 + the 3 added here).

The existing AES coverage already exercises the deferred path end to end — `test/crypto/aes_encryption_test.rb` constructs decrypters and runs `reset!` + `decrypt`, and `test/encryption_test.rb` reads the real `zip-aes-128` / `zip-aes-256` fixtures. Both pass unchanged.

The three added tests assert in a subprocess (the suite itself has already loaded openssl via the AES tests) that:
1. requiring `zip` does not load openssl — **fails against the previous code**
2. constructing an `AESDecrypter` does load it
3. AES decryption still produces the correct plaintext with no eager require

`rubocop` clean on both changed files.
