### PR TITLE
Forward options from blockless OutputStream.open

### DIFF
--- a/lib/zip/output_stream.rb
+++ b/lib/zip/output_stream.rb
@@ -53,7 +53,13 @@ module Zip
       # stream is passed to the block and closed when the block
       # returns.
       def open(file_name, encrypter: nil, suppress_extra_fields: false)
-        return new(file_name) unless block_given?
+        unless block_given?
+          return new(
+            file_name,
+            encrypter:             encrypter,
+            suppress_extra_fields: suppress_extra_fields
+          )
+        end
 
         zos = new(file_name, stream: false, encrypter: encrypter,
                   suppress_extra_fields: suppress_extra_fields)

--- a/test/output_stream_test.rb
+++ b/test/output_stream_test.rb
@@ -29,6 +29,20 @@ class ZipOutputStreamTest < Minitest::Test
     assert_test_zip_contents(TEST_ZIP)
   end
 
+  def test_open_without_block_forwards_options
+    encrypter = ::Zip::TraditionalEncrypter.new('password')
+    zos = ::Zip::OutputStream.open(
+      TEST_ZIP.zip_name,
+      encrypter:             encrypter,
+      suppress_extra_fields: true
+    )
+
+    assert_same encrypter, zos.instance_variable_get(:@encrypter)
+    assert_equal true, zos.instance_variable_get(:@suppress_extra_fields)
+  ensure
+    zos&.close
+  end
+
   def test_write_buffer
     buffer = ::Zip::OutputStream.write_buffer(::StringIO.new) do |zos|
       zos.comment = TEST_ZIP.comment


### PR DESCRIPTION
## Summary

Forward encrypter: and suppress_extra_fields: through the blockless Zip::OutputStream.open path instead of silently discarding them.

## Reproduction

The current blockless path returns new(file_name) while the block path forwards both public keywords. A dual-Ruby external model observes the missing encrypter and extra-field suppression on current main; this candidate preserves them.

## Verification

- Added an upstream regression test covering both forwarded options
- Focused output stream tests: 28 runs, 88 assertions, 0 failures
- Ruby 4.0.6 and 3.2.11 full suite before the follow-up: 416 tests, 2,857 assertions, 0 failures
- 115 Ruby files compile on both Rubies
- RuboCop: 119 files, 0 offenses
- 60-file gem builds successfully