### PR TITLE
Handle short reads in copy_stream_n

### DIFF
--- a/lib/zip/ioextras.rb
+++ b/lib/zip/ioextras.rb
@@ -13,8 +13,11 @@ module Zip
         toread = nbytes
         while toread > 0 && !istream.eof?
           tr = [toread, CHUNK_SIZE].min
-          ostream.write(istream.read(tr, +''))
-          toread -= tr
+          chunk = istream.read(tr, +'')
+          break if !chunk || chunk.empty?
+
+          ostream.write(chunk)
+          toread -= chunk.bytesize
         end
       end
     end


### PR DESCRIPTION
## Summary

Subtract the number of bytes actually returned by `read` in `copy_stream_n`, and stop cleanly when a stream returns `nil` or an empty chunk.

## Reproduction

`IOExtras.copy_stream_n` currently assumes every `read(requested_length)` returns the requested length. Valid IO-like objects may return a short chunk, causing the method to stop before copying the requested byte count. A dual-Ruby external short-read stream model reproduces the truncation on current `main` and copies the requested bytes with this candidate.

## Verification

- Ruby 4.0.6 and 3.2.11: 416 tests, 2,857 assertions, 0 failures
- 115 Ruby files compile on both Rubies
- RuboCop: 119 files, 0 offenses
- 60-file gem builds successfully

No repository tests were changed because the consuming audit prohibits upstream test edits.
