### PR TITLE
Retain required Zip64 offset fields

### DIFF
--- a/lib/zip/extra_field/zip64.rb
+++ b/lib/zip/extra_field/zip64.rb
@@ -59,8 +59,8 @@ module Zip
     # We can suppress the zip64 extra field unless we know the size is large or
     # the relative header offset is large (for central directory entries).
     def suppress?
-      !(@original_size && @original_size >= 0xFFFFFFFF) ||
-        (@relative_header_offset && @relative_header_offset >= 0xFFFFFFFF)
+      !((@original_size && @original_size >= 0xFFFFFFFF) ||
+        (@relative_header_offset && @relative_header_offset >= 0xFFFFFFFF))
     end
 
     def pack_for_local


### PR DESCRIPTION
## Summary

Keep the Zip64 extra field whenever either the original size or relative header offset requires 64-bit storage.

## Reproduction

`Zip64#suppress?` currently combines the size and offset conditions as `!large_size || large_offset`. This suppresses Zip64 when only the offset is large and also suppresses it when both are large. A focused dual-Ruby external model covers size-only, offset-only, both-large and neither-large cases; current `main` fails the required offset cases and this candidate passes all four.

## Verification

- Ruby 4.0.6 and 3.2.11: 416 tests, 2,857 assertions, 0 failures
- 115 Ruby files compile on both Rubies
- RuboCop: 119 files, 0 offenses
- 60-file gem builds successfully

No repository tests were changed because the consuming audit prohibits upstream test edits.
