### PR TITLE
Parse legacy Unix owner identifiers

### DIFF
--- a/lib/zip/extra_field/old_unix.rb
+++ b/lib/zip/extra_field/old_unix.rb
@@ -24,8 +24,8 @@ module Zip
       return if !size || size == 0
 
       atime, mtime, uid, gid = content.unpack('VVvv')
-      @uid ||= uid
-      @gid ||= gid
+      @uid = uid unless uid.nil?
+      @gid = gid unless gid.nil?
       @atime ||= atime
       @mtime ||= mtime # rubocop:disable Naming/MemoizedInstanceVariableName
     end


### PR DESCRIPTION
## Summary

Assign UID and GID values parsed from the legacy Unix extra field instead of retaining the constructor's initialized zero values.

## Reproduction

`OldUnix#initialize` sets `@uid` and `@gid` to zero, then `#merge` uses `||=` for the parsed values. Because zero is truthy, nonzero identifiers in a valid legacy field are never exposed. A dual-Ruby external binary-field model reproduces the zero results on current `main` and reads the encoded UID/GID with this candidate.

## Verification

- Ruby 4.0.6 and 3.2.11: 416 tests, 2,857 assertions, 0 failures
- 115 Ruby files compile on both Rubies
- RuboCop: 119 files, 0 offenses
- 60-file gem builds successfully

No repository tests were changed because the consuming audit prohibits upstream test edits.
